### PR TITLE
Feature/Better source mapillary detection

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-root = yes
+root = true
 
 [*]
 end_of_line = lf

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,11 @@
 image: registry.gitlab.com/josm/docker-library/openjdk-8-josmplugin:latest
 
+stages:
+  - build
+  - test
+  - deploy
+  - release
+
 ###############
 # Build stage #
 ###############
@@ -7,39 +13,47 @@ image: registry.gitlab.com/josm/docker-library/openjdk-8-josmplugin:latest
 assemble:
   stage: build
   script:
-  - ./gradlew assemble --stacktrace
+    - ./gradlew assemble --stacktrace
   artifacts:
     paths:
-    - build/
+      - build/
+  except:
+    - schedules
 
 java 11 assemble:
   stage: build
   image: registry.gitlab.com/josm/docker-library/openjdk-11-josmplugin:latest
   script:
-  - ./gradlew assemble --stacktrace
+    - ./gradlew assemble --stacktrace
   artifacts:
     paths:
-    - build/
+      - build/
+  except:
+    - schedules
 
 java 12 assemble:
   stage: build
   image: registry.gitlab.com/josm/docker-library/openjdk-12-josmplugin:latest
   script:
-  - ./gradlew assemble --stacktrace
+    - ./gradlew assemble --stacktrace
   artifacts:
     paths:
-    - build/
+      - build/
   allow_failure: true
+  except:
+    - schedules
 
 java 13 assemble:
   stage: build
   image: registry.gitlab.com/josm/docker-library/openjdk-13-josmplugin:latest
   script:
-  - ./gradlew assemble --stacktrace
+    - ./gradlew assemble --stacktrace
   artifacts:
     paths:
-    - build/
+      - build/
   allow_failure: true
+  except:
+    - schedules
 
 
 ##############
@@ -49,52 +63,64 @@ java 13 assemble:
 build:
   stage: test
   script:
-  - ./gradlew build generatePot --stacktrace
+    - ./gradlew build generatePot --stacktrace
   artifacts:
     paths:
     - build
   dependencies:
-  - assemble
+    - assemble
+  except:
+    - schedules
 
 min JOSM compile:
   stage: test
   script:
-  - ./gradlew compileJava_minJosm --stacktrace
+    - ./gradlew compileJava_minJosm --stacktrace
   dependencies:
-  - assemble
+    - assemble
+  except:
+    - schedules
 
 latest JOSM compile:
   stage: test
   script:
-  - ./gradlew compileJava_latestJosm --stacktrace
+    - ./gradlew compileJava_latestJosm --stacktrace
   dependencies:
-  - assemble
+    - assemble
+  only:
+    - schedules@JOSM/plugin/Mapillary
 
 java 11 build:
   stage: test
   image: registry.gitlab.com/josm/docker-library/openjdk-11-josmplugin:latest
   script:
-  - ./gradlew build --stacktrace
+    - ./gradlew build --stacktrace
   dependencies:
-  - java 11 assemble
+    - java 11 assemble
+  except:
+    - schedules
 
 java 12 build:
   stage: test
   image: registry.gitlab.com/josm/docker-library/openjdk-12-josmplugin:latest
   script:
-  - ./gradlew build --stacktrace
+    - ./gradlew build --stacktrace
   dependencies:
-  - java 12 assemble
+    - java 12 assemble
   allow_failure: true
+  except:
+    - schedules
 
 java 13 build:
   stage: test
   image: registry.gitlab.com/josm/docker-library/openjdk-13-josmplugin:latest
   script:
-  - ./gradlew build --stacktrace
+    - ./gradlew build --stacktrace
   dependencies:
-  - java 13 assemble
+    - java 13 assemble
   allow_failure: true
+  except:
+    - schedules
 
 
 ################
@@ -108,33 +134,37 @@ transifex.com:
     name: transifex.com
     url: https://www.transifex.com/josm/josm/josm-plugin_Mapillary/
   script:
-  - TX_TOKEN="$TRANSIFEX_TOKEN" tx push -s --no-interactive
+    - TX_TOKEN="$TRANSIFEX_TOKEN" tx push -s --no-interactive
   dependencies:
-  - build
+    - build
   only:
     refs:
-    - master@JOSM/Mapillary
+      - master@JOSM/plugin/Mapillary
     variables:
-    - $TRANSIFEX_TOKEN
+      - $TRANSIFEX_TOKEN
+  except:
+    - schedules
 
 codecov.io:
-  image: alpine:3.8
+  image: alpine:3.10
   stage: deploy
   environment:
     name: codecov.io
     url: https://codecov.io/gh/JOSM/Mapillary
   before_script:
-  - apk add --update curl bash
+    - apk add --update curl bash
   script:
-  - curl -s https://codecov.io/bash | bash
-  - curl -s https://codecov.io/bash | bash /dev/stdin -c -F model_and_api
+    - curl -s https://codecov.io/bash | bash
+    - curl -s https://codecov.io/bash | bash /dev/stdin -c -F model_and_api
   dependencies:
-  - build
+    - build
   only:
     refs:
-    - master@JOSM/Mapillary
+      - master@JOSM/plugin/Mapillary
     variables:
-    - $CODECOV_TOKEN
+      - $CODECOV_TOKEN
+  except:
+    - schedules
 
 sonarcloud.io:
   image: registry.gitlab.com/josm/docker-library/openjdk-8-josmplugin:latest
@@ -143,39 +173,41 @@ sonarcloud.io:
     name: sonarcloud.io
     url: https://sonarcloud.io/dashboard?id=org.openstreetmap.josm.plugins%3AMapillary
   script:
-  - ./gradlew -Dsonar.login=$SONAR_TOKEN sonarqube
+    - ./gradlew -Dsonar.login=$SONAR_TOKEN sonarqube
   dependencies:
-  - build
+    - build
   only:
     refs:
-    - master@JOSM/Mapillary
+      - master@JOSM/plugin/Mapillary
     variables:
-    - $SONAR_TOKEN
+      - $SONAR_TOKEN
+  except:
+    - schedules
 
 GitLab Maven repo:
   stage: deploy
   environment:
-    name: GitLab Maven Repository for JOSM plugins
-    url: https://gitlab.com/JOSM/Mapillary/-/packages
+    name: GitLab.com / Maven packages
+    url: https://gitlab.com/JOSM/plugin/Mapillary/-/packages
   script:
-  - ./gradlew publishAllPublicationsToGitlabRepository
-  - ./gradlew releaseToGitlab
+    - ./gradlew publishAllPublicationsToGitlabRepository
   dependencies:
-  - build
+    - build
   only:
-    refs:
-    - tags@JOSM/Mapillary
+    - tags@JOSM/plugin/Mapillary
+  except:
+    - schedules
 
 release:
   stage: deploy
   environment:
-    name: pages branch / dist directory
-    url: https://gitlab.com/JOSM/Mapillary/tree/pages/dist
+    name: GitLab.com / pages branch
+    url: https://gitlab.com/JOSM/plugin/Mapillary/tree/pages/dist
   script:
   - |
-    echo "$SSH_PRIVATE_DEPLOY_KEY" > ~/.ssh/id_rsa
+    base64 --decode "$SSH_PRIVATE_DEPLOY_KEY" > ~/.ssh/id_rsa
     chmod 600 ~/.ssh/id_rsa
-    git clone --depth 1 --branch pages git@gitlab.com:JOSM/Mapillary.git pages
+    git clone --depth 1 --branch pages git@gitlab.com:JOSM/plugin/Mapillary.git pages
   - |
     version=`git describe --always --dirty`
     longVersion=`git describe --always --long --dirty`
@@ -187,15 +219,33 @@ release:
     ln -s "./$version" "pages/dist/latest"
   - |
     cd pages/
-    git config user.name "GitLab CI for JOSM/Mapillary"
-    git config user.email "incoming+JOSM/Mapillary@incoming.gitlab.com"
+    git config user.name "GitLab CI for JOSM/plugin/Mapillary"
+    git config user.email "incoming+josm-plugin-mapillary-8564565-issue-@incoming.gitlab.com"
     git stage .
     git commit -a -m "$commitMessage"
     git push origin pages
   dependencies:
   - build
   only:
-    refs:
-    - tags@JOSM/Mapillary
-    variables:
-    - $SSH_PRIVATE_DEPLOY_KEY
+    - tags@JOSM/plugin/Mapillary
+  except:
+    - schedules
+
+
+#################
+# Release stage #
+#################
+
+release to Gitlab.com:
+  stage: release
+  environment:
+    name: GitLab.com / Releases
+    url: https://gitlab.com/JOSM/plugin/Mapillary/-/releases
+  script:
+    - ./gradlew releaseToGitlab
+  dependencies:
+    - GitLab Maven repo
+  only:
+    - tags@JOSM/plugin/Mapillary
+  except:
+    - schedules

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,9 @@
 image: registry.gitlab.com/josm/docker-library/openjdk-8-josmplugin:latest
 
+include:
+  - template: Dependency-Scanning.gitlab-ci.yml
+  - template: License-Scanning.gitlab-ci.yml
+
 stages:
   - build
   - test

--- a/.tx/config
+++ b/.tx/config
@@ -5,6 +5,6 @@ host = https://www.transifex.com
 file_filter = src/main/po/<lang>.po
 lang_map = ca@valencia: ca-valencia
 minimum_perc = 50
-source_file = build/i18n/josm-plugin_Mapillary.pot
+source_file = build/i18n/pot/josm-plugin_Mapillary.pot
 source_lang = en
 type = PO

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -5,7 +5,7 @@ But if you want to explore the sourcecode and maybe even improve it, first of al
 ## Setting up your local git-repo
 
 ```shell
-git clone git@github.com:JOSM/Mapillary.git
+git clone git@gitlab.com:JOSM/plugin/Mapillary.git
 cd Mapillary
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # [Mapillary](https://mapillary.com)-plugin for [JOSM](https://josm.openstreetmap.de)
 
-[![build status](https://gitlab.com/JOSM/Mapillary/badges/master/pipeline.svg)](https://gitlab.com/JOSM/Mapillary/pipelines)
-[![code coverage](https://gitlab.com/JOSM/Mapillary/badges/master/coverage.svg)](https://codecov.io/github/JOSM/Mapillary?branch=master)
-[![latest release](https://img.shields.io/github/release/JOSM/Mapillary.svg?style=flat-square&maxAge=7200)](https://gitlab.com/JOSM/Mapillary/releases)
-[![license: GPLv2 or later](https://img.shields.io/badge/license-GPLv2_or_later-blue.svg?style=flat-square&maxAge=7200)](https://gitlab.com/JOSM/Mapillary/blob/master/LICENSE.md)
+[![build status](https://gitlab.com/JOSM/plugin/Mapillary/badges/master/pipeline.svg)](https://gitlab.com/JOSM/plugin/Mapillary/pipelines)
+[![code coverage](https://gitlab.com/JOSM/plugin/Mapillary/badges/master/coverage.svg)](https://codecov.io/github/JOSM/Mapillary?branch=master)
+[![latest release](https://img.shields.io/github/release/JOSM/Mapillary.svg?style=flat-square&maxAge=7200)](https://gitlab.com/JOSM/plugin/Mapillary/releases)
+[![license: GPLv2 or later](https://img.shields.io/badge/license-GPLv2_or_later-blue.svg?style=flat-square&maxAge=7200)](https://gitlab.com/JOSM/plugin/Mapillary/blob/master/LICENSE.md)
 
 A plugin for showing Mapillary images inside the OpenStreetMap-Editor JOSM.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,10 +10,10 @@ import java.net.URL
 
 plugins {
   id("org.sonarqube") version "2.8"
-  id("org.openstreetmap.josm") version "0.6.4"
-  id("com.github.ben-manes.versions") version "0.25.0"
-  id("com.github.spotbugs") version "2.0.0"
-  id("net.ltgt.errorprone") version "0.8.1"
+  id("org.openstreetmap.josm") version "0.6.5"
+  id("com.github.ben-manes.versions") version "0.27.0"
+  id("com.github.spotbugs") version "2.0.1"
+  id("net.ltgt.errorprone") version "1.1.1"
 
   eclipse
   jacoco
@@ -54,13 +54,13 @@ base.archivesBaseName = "Mapillary"
 
 dependencies {
   testImplementation ("org.openstreetmap.josm:josm-unittest:SNAPSHOT"){ isChanging = true }
-  testImplementation("com.github.tomakehurst:wiremock:2.25.0")
+  testImplementation("com.github.tomakehurst:wiremock:2.25.1")
   val junitVersion = "5.5.2"
   testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
   testImplementation("org.junit.vintage:junit-vintage-engine:$junitVersion")
   testImplementation("org.awaitility:awaitility:4.0.1")
-  testImplementation("org.jmockit:jmockit:1.45")
+  testImplementation("org.jmockit:jmockit:1.46") { because("versions >= 1.47 are incompatible with JOSM, see https://josm.openstreetmap.de/ticket/18200") }
   testImplementation("com.github.spotbugs:spotbugs-annotations:3.1.12")
 }
 
@@ -105,7 +105,7 @@ josm {
     oldVersionDownloadLink(10824, "v1.5.3", URL("https://github.com/JOSM/Mapillary/releases/download/v1.5.3/Mapillary.jar"))
   }
   i18n {
-    pathTransformer = getPathTransformer("gitlab.com/JOSM/Mapillary/blob")
+    pathTransformer = getPathTransformer("gitlab.com/JOSM/plugin/Mapillary/blob")
   }
 }
 
@@ -158,7 +158,7 @@ project.afterEvaluate {
     pom {
       name.set("JOSM-${base.archivesBaseName}")
       description.set("The Mapillary plugin for JOSM")
-      url.set("https://gitlab.com/JOSM/Mapillary")
+      url.set("https://gitlab.com/JOSM/plugin/Mapillary")
       licenses {
         license {
           name.set("GNU General Public License Version 2")
@@ -166,9 +166,9 @@ project.afterEvaluate {
         }
       }
       scm {
-        connection.set("scm:git:git://gitlab.com/JOSM/Mapillary.git")
-        developerConnection.set("scm:git:ssh://gitlab.com/JOSM/Mapillary.git")
-        url.set("https://gitlab.com/JOSM/Mapillary")
+        connection.set("scm:git:git://gitlab.com/JOSM/plugin/Mapillary.git")
+        developerConnection.set("scm:git:ssh://gitlab.com/JOSM/plugin/Mapillary.git")
+        url.set("https://gitlab.com/JOSM/plugin/Mapillary")
       }
       issueManagement {
         system.set("Trac")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
   id("org.sonarqube") version "2.8"
   id("org.openstreetmap.josm") version "0.6.5"
   id("com.github.ben-manes.versions") version "0.27.0"
-  id("com.github.spotbugs") version "2.0.1"
+  id("com.github.spotbugs") version "3.0.0"
   id("net.ltgt.errorprone") version "1.1.1"
 
   eclipse
@@ -28,7 +28,7 @@ repositories {
 
 // Set up ErrorProne
 dependencies {
-  errorprone("com.google.errorprone:error_prone_core:2.3.3")
+  errorprone("com.google.errorprone:error_prone_core:2.3.4")
   if (!JavaVersion.current().isJava9Compatible) {
     errorproneJavac("com.google.errorprone:javac:9+181-r4173-1")
   }
@@ -54,14 +54,14 @@ base.archivesBaseName = "Mapillary"
 
 dependencies {
   testImplementation ("org.openstreetmap.josm:josm-unittest:SNAPSHOT"){ isChanging = true }
-  testImplementation("com.github.tomakehurst:wiremock:2.25.1")
-  val junitVersion = "5.5.2"
+  testImplementation("com.github.tomakehurst:wiremock:2.26.0")
+  val junitVersion = "5.6.0"
   testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
   testImplementation("org.junit.vintage:junit-vintage-engine:$junitVersion")
-  testImplementation("org.awaitility:awaitility:4.0.1")
+  testImplementation("org.awaitility:awaitility:4.0.2")
   testImplementation("org.jmockit:jmockit:1.46") { because("versions >= 1.47 are incompatible with JOSM, see https://josm.openstreetmap.de/ticket/18200") }
-  testImplementation("com.github.spotbugs:spotbugs-annotations:3.1.12")
+  testImplementation("com.github.spotbugs:spotbugs-annotations:4.0.0")
 }
 
 sourceSets {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,8 @@
 import com.github.spotbugs.SpotBugsTask
-import net.ltgt.gradle.errorprone.*
+import net.ltgt.gradle.errorprone.CheckSeverity
+import net.ltgt.gradle.errorprone.errorprone
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
-import org.openstreetmap.josm.gradle.plugin.config.GitlabConfig
-import org.openstreetmap.josm.gradle.plugin.config.I18nConfig
-import org.openstreetmap.josm.gradle.plugin.config.JosmManifest
 import org.openstreetmap.josm.gradle.plugin.task.MarkdownToHtml
 import java.net.URL
 

--- a/config/pmd/ruleset.xml
+++ b/config/pmd/ruleset.xml
@@ -18,7 +18,6 @@
   <rule ref="category/java/bestpractices.xml/ConstantsInInterface" />
   <rule ref="category/java/bestpractices.xml/DefaultLabelNotLastInSwitchStmt" />
   <rule ref="category/java/bestpractices.xml/LooseCoupling" />
-  <rule ref="category/java/bestpractices.xml/LooseCoupling" />
   <rule ref="category/java/bestpractices.xml/MethodReturnsInternalArray" />
   <rule ref="category/java/bestpractices.xml/PositionLiteralsFirstInCaseInsensitiveComparisons" />
   <rule ref="category/java/bestpractices.xml/PositionLiteralsFirstInComparisons" />
@@ -111,7 +110,6 @@
     <exclude name="DoNotCallSystemExit" />
     <exclude name="DoNotExtendJavaLangThrowable" />
     <exclude name="DoNotHardCodeSDCard" />
-    <exclude name="InvalidSlf4jMessageFormat" />
     <exclude name="JUnitSpelling" />
     <exclude name="JUnitStaticSuite" />
     <exclude name="LoggerIsNotStaticFinal" />

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-plugin.author=nokutu, floscher <incoming+JOSM/Mapillary@incoming.gitlab.com>
+plugin.author=nokutu, floscher <incoming+josm-plugin-mapillary-8564565-issue-@incoming.gitlab.com>
 plugin.canloadatruntime=true
 plugin.class=org.openstreetmap.josm.plugins.mapillary.MapillaryPlugin
 plugin.description=Allows the user to work with pictures hosted at mapillary.com
@@ -10,7 +10,7 @@ plugin.main.version=15371
 # Version of JOSM against which the plugin is compiled
 # Please check, if the specified version is available for download from https://josm.openstreetmap.de/download/ .
 # If not, choose the next higher number that is available, or the gradle build will break.
-plugin.compile.version=15438
+plugin.compile.version=15492
 plugin.requires=apache-commons;apache-http
 
 # Character encoding of Gradle files

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ plugin.main.version=15371
 # Version of JOSM against which the plugin is compiled
 # Please check, if the specified version is available for download from https://josm.openstreetmap.de/download/ .
 # If not, choose the next higher number that is available, or the gradle build will break.
-plugin.compile.version=15492
+plugin.compile.version=15806
 plugin.requires=apache-commons;apache-http
 
 # Character encoding of Gradle files

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,11 +6,11 @@ plugin.icon=images/mapillary-logo.svg
 plugin.link=https://wiki.openstreetmap.org/wiki/JOSM/Plugins/Mapillary
 # Minimum required JOSM version to run this plugin, choose the lowest version possible that is compatible.
 # You can check if the plugin compiles against this version by executing `./gradlew compileJava_minJosm`.
-plugin.main.version=15371
+plugin.main.version=15885
 # Version of JOSM against which the plugin is compiled
 # Please check, if the specified version is available for download from https://josm.openstreetmap.de/download/ .
 # If not, choose the next higher number that is available, or the gradle build will break.
-plugin.compile.version=15806
+plugin.compile.version=15885
 plugin.requires=apache-commons;apache-http
 
 # Character encoding of Gradle files

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,12 +5,12 @@ plugin.description=Allows the user to work with pictures hosted at mapillary.com
 plugin.icon=images/mapillary-logo.svg
 plugin.link=https://wiki.openstreetmap.org/wiki/JOSM/Plugins/Mapillary
 # Minimum required JOSM version to run this plugin, choose the lowest version possible that is compatible.
-# You can check if the plugin compiles against this version by executing `./gradlew minJosmVersionClasses`.
-plugin.main.version=14760
+# You can check if the plugin compiles against this version by executing `./gradlew compileJava_minJosm`.
+plugin.main.version=15371
 # Version of JOSM against which the plugin is compiled
 # Please check, if the specified version is available for download from https://josm.openstreetmap.de/download/ .
 # If not, choose the next higher number that is available, or the gradle build will break.
-plugin.compile.version=15238
+plugin.compile.version=15438
 plugin.requires=apache-commons;apache-http
 
 # Character encoding of Gradle files

--- a/gradle/tool-config.gradle
+++ b/gradle/tool-config.gradle
@@ -1,6 +1,6 @@
-def pmdVersion = "6.12.0"
-def spotbugsVersion = "3.1.12"
-def jacocoVersion = "0.8.3"
+def pmdVersion = "6.21.0"
+def spotbugsVersion = "4.0.0"
+def jacocoVersion = "0.8.5"
 
 // Spotbugs config
 spotbugs {

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/MapillaryLayer.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/MapillaryLayer.java
@@ -413,6 +413,11 @@ public final class MapillaryLayer extends AbstractModifiableLayer implements
   }
 
   @Override
+  public String getChangesetSourceTag() {
+    return "mapillary";
+  }
+
+  @Override
   public boolean isMergable(Layer other) {
     return false;
   }

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/MapillaryLayer.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/MapillaryLayer.java
@@ -414,7 +414,7 @@ public final class MapillaryLayer extends AbstractModifiableLayer implements
 
   @Override
   public String getChangesetSourceTag() {
-    return "mapillary";
+    return "Mapillary";
   }
 
   @Override

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryFilterDialog.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryFilterDialog.java
@@ -207,7 +207,7 @@ public final class MapillaryFilterDialog extends ToggleDialog implements Mapilla
   }
 
   private boolean checkValidTime(MapillaryAbstractImage img) {
-    Long currentTime = currentTime();
+    final long currentTime = currentTime();
     for (int i = 0; i < 3; i++) {
       if (TIME_LIST[i].equals(time.getSelectedItem()) &&
         img.getCapturedAt() < currentTime - spinnerModel.getNumber().doubleValue() * TIME_FACTOR[i]) {

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryImageDisplay.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryImageDisplay.java
@@ -279,9 +279,7 @@ public class MapillaryImageDisplay extends JPanel {
         return;
       }
       if (this.mouseIsDragging) {
-        if (MapillaryImageDisplay.this.pano) {
-          // do nothing.
-        } else {
+        if (!MapillaryImageDisplay.this.pano) {
           Point p = comp2imgCoord(visibleRect, e.getX(), e.getY());
           visibleRect.x += this.mousePointInImg.x - p.x;
           visibleRect.y += this.mousePointInImg.y - p.y;
@@ -292,14 +290,14 @@ public class MapillaryImageDisplay extends JPanel {
           MapillaryImageDisplay.this.repaint();
         }
       } else if (MapillaryImageDisplay.this.selectedRect != null) {
-        Point p = comp2imgCoord(visibleRect, e.getX(), e.getY());
+        final Point p = comp2imgCoord(visibleRect, e.getX(), e.getY());
         checkPointInVisibleRect(p, visibleRect);
-        Rectangle rect = new Rectangle(p.x < this.mousePointInImg.x ? p.x
-            : this.mousePointInImg.x, p.y < this.mousePointInImg.y ? p.y
-            : this.mousePointInImg.y, p.x < this.mousePointInImg.x ? this.mousePointInImg.x
-            - p.x : p.x - this.mousePointInImg.x,
-            p.y < this.mousePointInImg.y ? this.mousePointInImg.y - p.y : p.y
-                - this.mousePointInImg.y);
+        Rectangle rect = new Rectangle(
+          Math.min(p.x, this.mousePointInImg.x),
+          Math.min(p.y, this.mousePointInImg.y),
+          Math.abs(p.x - this.mousePointInImg.x),
+          Math.abs(p.y - this.mousePointInImg.y)
+        );
         checkVisibleRectSize(image, rect);
         checkVisibleRectPos(image, rect);
         MapillaryImageDisplay.this.selectedRect = rect;

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryMainDialog.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryMainDialog.java
@@ -273,12 +273,12 @@ public final class MapillaryMainDialog extends ToggleDialog implements
           }
         }
       } else if (this.image instanceof MapillaryImportedImage) {
-        MapillaryImportedImage mapillaryImage = (MapillaryImportedImage) this.image;
+        final MapillaryImportedImage mapillaryImage = (MapillaryImportedImage) this.image;
         try {
           this.mapillaryImageDisplay.setImage(
             mapillaryImage.getImage(),
             null,
-            mapillaryImage != null && mapillaryImage.isPanorama()
+            mapillaryImage.isPanorama()
           );
         } catch (IOException e) {
           Logging.error(e);

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryMainDialog.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryMainDialog.java
@@ -306,6 +306,9 @@ public final class MapillaryMainDialog extends ToggleDialog implements
    */
   public synchronized void setImage(MapillaryAbstractImage image) {
     this.image = image;
+    if (this.isVisible() && MapillaryLayer.hasInstance()) {
+      MapillaryLayer.getInstance().setImageViewed(this.image);
+    }
   }
 
   /**
@@ -479,5 +482,12 @@ public final class MapillaryMainDialog extends ToggleDialog implements
   @Override
   public void imagesAdded() {
     // This method is enforced by MapillaryDataListener, but only selectedImageChanged() is needed
+  }
+
+  @Override
+  public void showDialog() {
+    super.showDialog();
+    if (this.image != null)
+      MapillaryLayer.getInstance().setImageViewed(this.image);
   }
 }

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryPreferenceSetting.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryPreferenceSetting.java
@@ -198,7 +198,7 @@ public class MapillaryPreferenceSetting implements SubPreferenceSetting, Mapilla
   @SuppressWarnings("PMD.ShortMethodName")
   @Override
   public boolean ok() {
-    MapillaryProperties.DOWNLOAD_MODE.put(DOWNLOAD_MODE.fromLabel(downloadModeComboBox.getSelectedItem().toString()).getPrefId());
+    MapillaryProperties.DOWNLOAD_MODE.put(DOWNLOAD_MODE.fromLabel(downloadModeComboBox.getItemAt(downloadModeComboBox.getSelectedIndex())).getPrefId());
     MapillaryProperties.DISPLAY_HOUR.put(displayHour.isSelected());
     MapillaryProperties.TIME_FORMAT_24.put(format24.isSelected());
     MapillaryProperties.MOVE_TO_IMG.put(moveTo.isSelected());

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/panorama/CameraPlane.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/panorama/CameraPlane.java
@@ -25,11 +25,11 @@ public class CameraPlane {
     this.distance = distance;
     setRotation(0.0, 0.0);
     vectors = new Vector3D[width][height];
-    IntStream.range(0, height).parallel().forEach(y -> {
-      IntStream.range(0, width).parallel().forEach(x -> {
-        vectors[x][y] = new Vector3D(x - width / 2d, y - height / 2d, distance).normalize();
-      });
-    });
+    IntStream.range(0, height).parallel().forEach(
+      y -> IntStream.range(0, width).parallel().forEach(
+        x -> vectors[x][y] = new Vector3D(x - width / 2d, y - height / 2d, distance).normalize()
+      )
+    );
   }
 
   /**
@@ -123,14 +123,16 @@ public class CameraPlane {
   }
 
   public void mapping(BufferedImage sourceImage, BufferedImage targetImage) {
-    IntStream.range(0, targetImage.getHeight()).parallel().forEach(y -> {
-      IntStream.range(0, targetImage.getWidth()).forEach(x -> {
-        final Vector3D vec = getVector3D(new Point(x, y));
-        final Point2D.Double p = UVMapping.getTextureCoordinate(vec);
-        targetImage.setRGB(x, y,
-            sourceImage.getRGB((int) (p.x * (sourceImage.getWidth() - 1)), (int) (p.y * (sourceImage.getHeight() - 1)))
-        );
-      });
-    });
+    IntStream.range(0, targetImage.getHeight()).parallel().forEach(
+      y -> IntStream.range(0, targetImage.getWidth()).forEach(
+        x -> {
+          final Vector3D vec = getVector3D(new Point(x, y));
+          final Point2D.Double p = UVMapping.getTextureCoordinate(vec);
+          targetImage.setRGB(x, y,
+              sourceImage.getRGB((int) (p.x * (sourceImage.getWidth() - 1)), (int) (p.y * (sourceImage.getHeight() - 1)))
+          );
+        }
+      )
+    );
   }
 }

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/mode/SelectMode.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/mode/SelectMode.java
@@ -70,8 +70,8 @@ public class SelectMode extends AbstractMode {
           final int j = lastClicked.getSequence().getImages().indexOf(lastClicked);
           MapillaryLayer.getInstance().getData().addMultiSelectedImage(
             new ConcurrentSkipListSet<>(closest.getSequence().getImages().subList(
-              i < j ? i : j,
-              i < j ? j + 1 : i + 1
+              Math.min(i, j),
+              Math.max(i, j) + 1
             ))
           );
         }

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/oauth/OAuthPortListener.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/oauth/OAuthPortListener.java
@@ -8,6 +8,7 @@ import java.io.PrintWriter;
 import java.net.BindException;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.nio.charset.StandardCharsets;
 import java.util.Scanner;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -40,10 +41,10 @@ public class OAuthPortListener extends Thread {
   @Override
   public void run() {
     try (
-        ServerSocket serverSocket = new ServerSocket(PORT);
-        Socket clientSocket = serverSocket.accept();
-        PrintWriter out = new PrintWriter(new OutputStreamWriter(clientSocket.getOutputStream(), "UTF-8"), true);
-        Scanner in = new Scanner(new InputStreamReader(clientSocket.getInputStream(), "UTF-8"))
+      ServerSocket serverSocket = new ServerSocket(PORT);
+      Socket clientSocket = serverSocket.accept();
+      PrintWriter out = new PrintWriter(new OutputStreamWriter(clientSocket.getOutputStream(), StandardCharsets.UTF_8), true);
+      Scanner in = new Scanner(new InputStreamReader(clientSocket.getInputStream(), StandardCharsets.UTF_8))
     ) {
       String s;
       String accessToken = null;

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/oauth/OAuthUtils.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/oauth/OAuthUtils.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 
 import javax.json.Json;
 import javax.json.JsonException;
@@ -42,7 +43,7 @@ public final class OAuthUtils {
     con.setRequestProperty("Authorization", "Bearer " + MapillaryProperties.ACCESS_TOKEN.get());
 
     try (
-      JsonReader reader = Json.createReader(new BufferedReader(new InputStreamReader(con.getInputStream(), "UTF-8")))
+      JsonReader reader = Json.createReader(new BufferedReader(new InputStreamReader(con.getInputStream(), StandardCharsets.UTF_8)))
     ) {
       return reader.readObject();
     } catch (JsonException e) {

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/ImageMetaDataUtil.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/ImageMetaDataUtil.java
@@ -1,15 +1,12 @@
 // License: GPL. For details, see LICENSE file.
 package org.openstreetmap.josm.plugins.mapillary.utils;
 
-import java.awt.image.BufferedImage;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
 
-import javax.imageio.ImageIO;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.ParserConfigurationException;
 
@@ -26,7 +23,7 @@ import org.openstreetmap.josm.tools.Logging;
 import org.openstreetmap.josm.tools.XmlUtils;
 
 
-public class ImageMetaDataUtil {
+public final class ImageMetaDataUtil {
 
   private ImageMetaDataUtil() {
     // private util.

--- a/src/main/po/be.po
+++ b/src/main/po/be.po
@@ -1,15 +1,15 @@
 # Translations for the JOSM plugin 'Mapillary' (be)
-# Copyright (C) 2018 
+# Copyright (C) 2020
 # This file is distributed under the same license as the josm-plugin_Mapillary package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
-#, fuzzy
+#
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: josm-plugin_Mapillary v1.5.16-14-g82b2768\n"
+"Project-Id-Version: josm-plugin_Mapillary 1.5.20-3-ge40f8de\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-30 10:39+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"POT-Creation-Date: 2020-02-17 00:25+0000\n"
+"PO-Revision-Date: 2018-01-15 10:33+0000\n"
 "Language-Team: Belarusian (https://www.transifex.com/josm/teams/2544/be/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -37,7 +37,6 @@ msgstr ""
 msgid "Cancel"
 msgstr "Скасаваць"
 
-#, java-format
 msgid "Changeset upload failed with {0} error ''{1} {2}''!"
 msgstr ""
 "Не атрымалася адправіць пакет правак па версіі пратакола {0} з абмылай: "
@@ -58,7 +57,6 @@ msgstr "Дні"
 msgid "Delete after upload"
 msgstr "Выдаліць пасля адпраўкі"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Display hour when the picture was taken"
 msgstr "Паказваць час, калі быў зроблены здымак"
 
@@ -92,7 +90,6 @@ msgstr "Адсылка скончана"
 msgid "Follow selected image"
 msgstr "Прытрымлівацца вылучанага здымка"
 
-#. i18n: traffic sign
 msgid "Give way"
 msgstr "Даць дарогу"
 
@@ -120,7 +117,6 @@ msgstr "Імпартаваць выявы на пласт Mapillary"
 msgid "Imported images"
 msgstr "Імпартаваныя выявы"
 
-#. i18n: traffic sign
 msgid "Intersection danger"
 msgstr "Перакрыжаванне з другаснай"
 
@@ -151,7 +147,6 @@ msgstr "Уваход паспяхова выкананы, зварот у JOSM."
 msgid "Logout"
 msgstr "Выйсці"
 
-#. i18n: traffic sign
 msgid "Mandatory direction (any)"
 msgstr "Кірунак руху"
 
@@ -182,25 +177,18 @@ msgstr "Месяцы"
 msgid "Next picture"
 msgstr "Наступны здымак"
 
-#. i18n: traffic sign
 msgid "No entry"
 msgstr "Заезд забаронены"
-
-msgid "No image selected"
-msgstr "Выява не абрана"
 
 msgid "No images found"
 msgstr "Выявы не знойдзеныя"
 
-#. i18n: traffic sign
 msgid "No overtaking"
 msgstr "Абгон забаронены"
 
-#. i18n: traffic sign
 msgid "No parking"
 msgstr "Стаянка забаронена"
 
-#. i18n: traffic sign
 msgid "No turn"
 msgstr "Паварот забаронены"
 
@@ -228,14 +216,12 @@ msgstr "Прыпыніць"
 msgid "Pauses the walk."
 msgstr "Прыпыніць шпацыр."
 
-#. i18n: traffic sign
 msgid "Pedestrian crossing"
 msgstr "Пешаходны пераход"
 
 msgid "Play"
 msgstr "Прайграць"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Preview images when hovering its icon"
 msgstr "Перадпрагляд выявы пры навядзенні на яго значок"
 
@@ -251,7 +237,6 @@ msgstr "Скід"
 msgid "Rewrite imported images"
 msgstr "Перазапісаць імпартаваныя выявы"
 
-#. i18n: traffic sign
 msgid "Roundabout"
 msgstr "Круг"
 
@@ -267,7 +252,6 @@ msgstr "Паказвае наступны здымак паслядоўнасц�
 msgid "Shows the previous picture in the sequence"
 msgstr "Паказвае папярэдні здымак паслядоўнасці"
 
-#. i18n: traffic sign
 msgid "Speed limit"
 msgstr "Абмежаванне хуткасці"
 
@@ -275,7 +259,6 @@ msgctxt "as synonym to halt or stand still"
 msgid "Stop"
 msgstr "Стоп"
 
-#. i18n: traffic sign
 msgctxt "name of the traffic sign"
 msgid "Stop"
 msgstr "Стоп"
@@ -289,7 +272,6 @@ msgstr "Перадаць пакет правак"
 msgid "Submit the current changeset"
 msgstr "Перадаць бягучы пакет правак"
 
-#. CHECKSTYLE.OFF: LineLength
 msgid "Submit the current changeset to Mapillary"
 msgstr "Перадаць бягучы пакет правак у Mapillary"
 
@@ -305,14 +287,12 @@ msgstr "Падтрымоўваныя фарматы малюнкаў (JPG і PNG
 msgid "Tag conflict"
 msgstr "Канфлікт у тэгах"
 
-#, java-format
 msgid "Total Mapillary images: {0}"
 msgstr "Усяго здымкаў Mapillary: {0}"
 
 msgid "Undo"
 msgstr "Вярнуць"
 
-#. i18n: traffic sign
 msgid "Uneven road"
 msgstr "Няроўная дарога"
 
@@ -322,11 +302,9 @@ msgstr "Абнавіць"
 msgid "Upload selected sequence"
 msgstr "Адаслаць вылучаную паслядоўнасць"
 
-#, java-format
 msgid "Uploading: {0}"
 msgstr "Адсылаецца: {0}"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Use 24 hour format"
 msgstr "Выкарыстоўваць 24-гадзінны фармат"
 
@@ -345,7 +323,6 @@ msgstr "Гады"
 msgid "You are currently not logged in."
 msgstr "Вы не выканалі ўваход."
 
-#, java-format
 msgid "You are logged in as ''{0}''."
 msgstr "Вы ўвайшлі як ''{0}''."
 
@@ -358,22 +335,18 @@ msgstr "Маштабаваць да вылучанага здымка"
 msgid "Zoom to the currently selected Mapillary image"
 msgstr "Наблізіцца да бягучага вылучанага здымка Mapillary"
 
-#. i18n: download mode for Mapillary images
 msgid "areas with downloaded OSM-data"
 msgstr "вобласці са спампаванымі дадзенымі OSM"
 
-#. i18n: download mode for Mapillary images
 msgid "everything in the visible area"
 msgstr "усё ў бачнай вобласці"
 
-#. i18n: download mode for Mapillary images
 msgid "only when manually requested"
 msgstr "толькі пры запыце ўручную"
 
 msgid "pending"
 msgstr "у чаканні"
 
-#. Plugin description for Mapillary
 msgid "Allows the user to work with pictures hosted at mapillary.com"
 msgstr ""
 "Дазваляе карыстальнікам працаваць з выявамі, размешчанымі на mapillary.com"

--- a/src/main/po/ca.po
+++ b/src/main/po/ca.po
@@ -1,15 +1,15 @@
 # Translations for the JOSM plugin 'Mapillary' (ca)
-# Copyright (C) 2018 
+# Copyright (C) 2020
 # This file is distributed under the same license as the josm-plugin_Mapillary package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
-#, fuzzy
+#
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: josm-plugin_Mapillary v1.5.16-14-g82b2768\n"
+"Project-Id-Version: josm-plugin_Mapillary 1.5.20-3-ge40f8de\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-30 10:39+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"POT-Creation-Date: 2020-02-17 00:25+0000\n"
+"PO-Revision-Date: 2018-01-15 10:33+0000\n"
 "Language-Team: Catalan (https://www.transifex.com/josm/teams/2544/ca/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -23,7 +23,6 @@ msgstr "2 imatges afegides"
 msgid "2 images unjoined"
 msgstr "2 imatges tretes"
 
-#, java-format
 msgid ""
 "A tag with key <i>{0}</i> is already present on the selected OSM object."
 msgstr ""
@@ -53,7 +52,6 @@ msgstr ""
 msgid "Cancel"
 msgstr "Cancel·la"
 
-#, java-format
 msgid "Changeset upload failed with {0} error ''{1} {2}''!"
 msgstr "El conjunt de canvis pujat ha fallat amb {0} errors ''{1} {2}''!"
 
@@ -69,26 +67,21 @@ msgstr "Copiar clau"
 msgid "Could not import a geotagged image to the Mapillary layer!"
 msgstr "No s'ha pogut importar una imatge geoetiquetada a la capa Mapillary!"
 
-#, java-format
 msgid "Could not import the directory ''{0}''!"
 msgstr "No s'`ha pogut importar el directori ''{0}''!"
 
-#, java-format
 msgid "Could not import the image ''{0}''!"
 msgstr "No s'ha pogut importar la imatge ''{0}''!"
 
-#, java-format
 msgid "Could not open the URL {0} in a browser"
 msgstr "No s'ha pogut obrir la URL {0} en un navegador"
 
-#, java-format
 msgid "Could not read from URL {0}!"
 msgstr "No s'ha pogut llegir des de la URL {0}!"
 
 msgid "Current Mapillary changeset"
 msgstr "Conjunt de canvis del Mapillary actual"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Cut off sequences at download bounds"
 msgstr "Talla les seqüències als límits de descàrrega"
 
@@ -98,13 +91,11 @@ msgstr "Dies"
 msgid "Delete after upload"
 msgstr "Suprimeix un cop s''hagi pujat"
 
-#, java-format
 msgid "Deleted {0} image"
 msgid_plural "Deleted {0} images"
 msgstr[0] "Suprimida {0} imatge"
 msgstr[1] "Suprimides {0} imatges"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Display hour when the picture was taken"
 msgstr "Mostra l''hora a la qual es van fer les fotografies"
 
@@ -121,7 +112,6 @@ msgid "Displays the layer displaying the map objects detected by Mapillary"
 msgstr ""
 "Mostra la capa on es mostren els objectes de mapa detectats per Mapillary"
 
-#, java-format
 msgid ""
 "Do you really want to replace the current value <i>{0}</i> with the new "
 "value <i>{1}</i>?"
@@ -150,7 +140,6 @@ msgstr "Descarregant objectes de mapa..."
 msgid "Downloading…"
 msgstr "Descarregant..."
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Enable experimental beta-features (might be unstable)"
 msgstr "Habilitar funcions beta experimentals (podria ser inestable)"
 
@@ -184,7 +173,6 @@ msgstr "Des d'una capa d'imatges existent"
 msgid "From which source do you want to import images to the Mapillary layer?"
 msgstr "Des de quin origen vol importar les imatges a la capa Mapillary?"
 
-#. i18n: traffic sign
 msgid "Give way"
 msgstr "Cediu el pas"
 
@@ -232,13 +220,11 @@ msgstr "Importa imatges a la capa de Mapillary"
 msgid "Imported images"
 msgstr "Imatges importades"
 
-#, java-format
 msgid "Imported {0} image"
 msgid_plural "Imported {0} images"
 msgstr[0] "Importada {0} imatge"
 msgstr[1] "Importades {0} imatges"
 
-#. i18n: traffic sign
 msgid "Intersection danger"
 msgstr "Intersecció"
 
@@ -269,7 +255,6 @@ msgstr "Sessió iniciada correctament, retorn a JOSM."
 msgid "Logout"
 msgstr "Tanca la sessió"
 
-#. i18n: traffic sign
 msgid "Mandatory direction (any)"
 msgstr "Sentit obligatori"
 
@@ -294,7 +279,6 @@ msgstr "Inici de sessió de Mapillar"
 msgid "Months"
 msgstr "Mesos"
 
-#, java-format
 msgid "Moved {0} image"
 msgid_plural "Moved {0} images"
 msgstr[0] "{0} imatge moguda"
@@ -303,25 +287,18 @@ msgstr[1] "{0} imatges mogudes"
 msgid "Next picture"
 msgstr "Imatge següent"
 
-#. i18n: traffic sign
 msgid "No entry"
 msgstr "Entrada prohibida"
-
-msgid "No image selected"
-msgstr "No heu seleccionat cap imatge"
 
 msgid "No images found"
 msgstr "No s''ha trobat cap imatge"
 
-#. i18n: traffic sign
 msgid "No overtaking"
 msgstr "Avançament prohibit"
 
-#. i18n: traffic sign
 msgid "No parking"
 msgstr "Estacionament prohibit"
 
-#. i18n: traffic sign
 msgid "No turn"
 msgstr "Gir prohibit"
 
@@ -346,7 +323,6 @@ msgstr "Pausa"
 msgid "Pauses the walk."
 msgstr "Posa en pausa la caminada."
 
-#. i18n: traffic sign
 msgid "Pedestrian crossing"
 msgstr "Pas de vianants"
 
@@ -365,7 +341,6 @@ msgstr "Reinicia"
 msgid "Rewrite imported images"
 msgstr "Reescriu les imatges importades"
 
-#. i18n: traffic sign
 msgid "Roundabout"
 msgstr "Rotonda"
 
@@ -381,7 +356,6 @@ msgstr "Mostra la següent imatge de la seqüència"
 msgid "Shows the previous picture in the sequence"
 msgstr "Mostra la imatge anterior de la seqüència"
 
-#. i18n: traffic sign
 msgid "Speed limit"
 msgstr "Límit de velocitat"
 
@@ -389,7 +363,6 @@ msgctxt "as synonym to halt or stand still"
 msgid "Stop"
 msgstr "Stop"
 
-#. i18n: traffic sign
 msgctxt "name of the traffic sign"
 msgid "Stop"
 msgstr "Stop"
@@ -403,11 +376,9 @@ msgstr "Els formats de fitxer suportats  són JPG i PNG"
 msgid "Tag conflict"
 msgstr "Conflicte d'etiquetes"
 
-#, java-format
 msgid "Total Mapillary images: {0}"
 msgstr "Nombre total d''imatges de Mapillary: {0}"
 
-#, java-format
 msgid "Turned {0} image"
 msgid_plural "Turned {0} images"
 msgstr[0] "{0} imatge girada"
@@ -416,7 +387,6 @@ msgstr[1] "{0} imatges girades"
 msgid "Undo"
 msgstr "Desfés"
 
-#. i18n: traffic sign
 msgid "Uneven road"
 msgstr "Perfil irregular"
 
@@ -426,11 +396,9 @@ msgstr "Actualitza"
 msgid "Upload selected sequence"
 msgstr "Puja la seqüència seleccionada"
 
-#, java-format
 msgid "Uploading: {0}"
 msgstr "Pujant: {0}"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Use 24 hour format"
 msgstr "Utilitza un format de 24 hores"
 
@@ -452,7 +420,6 @@ msgstr "Anys"
 msgid "You are currently not logged in."
 msgstr "Ara no esteu connectat."
 
-#, java-format
 msgid "You are logged in as ''{0}''."
 msgstr "Esteu connectat com ''{0}''."
 

--- a/src/main/po/cs.po
+++ b/src/main/po/cs.po
@@ -1,15 +1,15 @@
 # Translations for the JOSM plugin 'Mapillary' (cs)
-# Copyright (C) 2018 
+# Copyright (C) 2020
 # This file is distributed under the same license as the josm-plugin_Mapillary package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
-#, fuzzy
+#
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: josm-plugin_Mapillary v1.5.16-14-g82b2768\n"
+"Project-Id-Version: josm-plugin_Mapillary 1.5.20-3-ge40f8de\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-30 10:39+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"POT-Creation-Date: 2020-02-17 00:25+0000\n"
+"PO-Revision-Date: 2018-01-15 10:33+0000\n"
 "Language-Team: Czech (https://www.transifex.com/josm/teams/2544/cs/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -23,7 +23,6 @@ msgstr "2 obrázky sloučeny"
 msgid "2 images unjoined"
 msgstr "2 obrázky rozděleny"
 
-#, java-format
 msgid ""
 "A tag with key <i>{0}</i> is already present on the selected OSM object."
 msgstr "Značka s klíčem <i>{0}</i> je již na vybraném objektu OSM přítomna."
@@ -51,7 +50,6 @@ msgstr ""
 msgid "Cancel"
 msgstr "Zrušit"
 
-#, java-format
 msgid "Changeset upload failed with {0} error ''{1} {2}''!"
 msgstr "Nahrání sady změn na server selhalo s {0} chybou ''{1} {2}''!"
 
@@ -68,26 +66,21 @@ msgid "Could not import a geotagged image to the Mapillary layer!"
 msgstr ""
 "Nepodařilo se importovat obrázek se zem. souřadnicemi do vrstvy Mapillary!"
 
-#, java-format
 msgid "Could not import the directory ''{0}''!"
 msgstr "Nepodařilo se importovat adresář ''{0}''!"
 
-#, java-format
 msgid "Could not import the image ''{0}''!"
 msgstr "Nepodařilo se importovat obrázek ''{0}''!"
 
-#, java-format
 msgid "Could not open the URL {0} in a browser"
 msgstr "Nemohu otevřít URL {0} v prohlížeči"
 
-#, java-format
 msgid "Could not read from URL {0}!"
 msgstr "Nelze číst z URL {0}!"
 
 msgid "Current Mapillary changeset"
 msgstr "Aktuální sada změn Mapillary"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Cut off sequences at download bounds"
 msgstr "Useknout sekvence na hranicích stahování"
 
@@ -97,7 +90,6 @@ msgstr "Dnů"
 msgid "Delete after upload"
 msgstr "Smazat po nahrání"
 
-#, java-format
 msgid "Deleted {0} image"
 msgid_plural "Deleted {0} images"
 msgstr[0] "Smazán {0} obrázek"
@@ -105,7 +97,6 @@ msgstr[1] "Smazány {0} obrázky"
 msgstr[2] "Smazáno {0} obrázků"
 msgstr[3] "Smazáno {0} obrázků"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Display hour when the picture was taken"
 msgstr "Zobrazit hodinu, kdy byl obrázek pořízen"
 
@@ -118,7 +109,6 @@ msgstr "Zobrazí objekty detekované Mapillary z jejich fotografií ulic"
 msgid "Displays the layer displaying the map objects detected by Mapillary"
 msgstr "Zobrazí vrstvu, ve které jsou mapové objekty detekované Mapillary"
 
-#, java-format
 msgid ""
 "Do you really want to replace the current value <i>{0}</i> with the new "
 "value <i>{1}</i>?"
@@ -144,7 +134,6 @@ msgstr "Stažení objektů mapy selhalo!"
 msgid "Downloading map objects…"
 msgstr "Stahuji objekty mapy..."
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Enable experimental beta-features (might be unstable)"
 msgstr "Povolit experimentální beta-funkce (může být nestabilní)"
 
@@ -175,7 +164,6 @@ msgstr "Z existující vrstvy obrázků"
 msgid "From which source do you want to import images to the Mapillary layer?"
 msgstr "Z jakého zdroje chcete importovat obrázky do vrstvy Mapillary?"
 
-#. i18n: traffic sign
 msgid "Give way"
 msgstr "Dej přednost"
 
@@ -221,7 +209,6 @@ msgstr "Importovat obrázky do vrstvy Mapillary"
 msgid "Imported images"
 msgstr "Importované obrázky"
 
-#, java-format
 msgid "Imported {0} image"
 msgid_plural "Imported {0} images"
 msgstr[0] "Importován {0} obrázek"
@@ -229,7 +216,6 @@ msgstr[1] "Importovány {0} obrázky"
 msgstr[2] "Importováno {0} obrázků"
 msgstr[3] "Importováno {0} obrázků"
 
-#. i18n: traffic sign
 msgid "Intersection danger"
 msgstr "Upozornění na křižovatku"
 
@@ -267,7 +253,6 @@ msgstr "Přihlášení úspěšné, návrat do JOSM."
 msgid "Logout"
 msgstr "Odhlásit se"
 
-#. i18n: traffic sign
 msgid "Mandatory direction (any)"
 msgstr "Přikázaný směr jízdy (jakýkoliv)"
 
@@ -304,7 +289,6 @@ msgstr "Objekty Mapillary"
 msgid "Months"
 msgstr "Měsíců"
 
-#, java-format
 msgid "Moved {0} image"
 msgid_plural "Moved {0} images"
 msgstr[0] "Posunut {0} obrázek"
@@ -315,32 +299,24 @@ msgstr[3] "Posunuto {0} obrázků"
 msgid "Next picture"
 msgstr "Další obrázek"
 
-#. i18n: traffic sign
 msgid "No entry"
 msgstr "Zákaz vjezdu"
-
-msgid "No image selected"
-msgstr "Nebyl vybrán žádný obrázek"
 
 msgid "No images found"
 msgstr "Nebyly nalezeny žádné obrázky"
 
-#. i18n: traffic sign
 msgid "No overtaking"
 msgstr "Zákaz předjíždění"
 
-#. i18n: traffic sign
 msgid "No parking"
 msgstr "Zákaz parkování"
 
-#. i18n: traffic sign
 msgid "No turn"
 msgstr "Zákaz odbočení"
 
 msgid "Not older than: "
 msgstr "Ne starší než: "
 
-#. i18n: Spinner label in JOSM settings
 msgid "Number of images to be pre-fetched (forwards and backwards)"
 msgstr "Počet snímků, která se mají načíst dopředu (vpřed a vzad)"
 
@@ -368,18 +344,15 @@ msgstr "Pozastavit"
 msgid "Pauses the walk."
 msgstr "Pozastaví průchod."
 
-#. i18n: traffic sign
 msgid "Pedestrian crossing"
 msgstr "Přechod pro chodce"
 
 msgid "Play"
 msgstr "Přehrát"
 
-#, java-format
 msgid "Press \"{0}\" to download images"
 msgstr "Stiskněte \"{0}\" pro stažení obrázků"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Preview images when hovering its icon"
 msgstr "Nahlédnout obrázek při ukázání na jeho ikonu"
 
@@ -395,7 +368,6 @@ msgstr "Reset"
 msgid "Rewrite imported images"
 msgstr "Přepsat importované obrázky"
 
-#. i18n: traffic sign
 msgid "Roundabout"
 msgstr "Kruhový objezd"
 
@@ -423,7 +395,6 @@ msgstr "Ukáže další obrázek v sekvenci"
 msgid "Shows the previous picture in the sequence"
 msgstr "Ukáže předchozí obrázek v sekvenci"
 
-#. i18n: traffic sign
 msgid "Speed limit"
 msgstr "Omezení rychlosti"
 
@@ -431,7 +402,6 @@ msgctxt "as synonym to halt or stand still"
 msgid "Stop"
 msgstr "Stop"
 
-#. i18n: traffic sign
 msgctxt "name of the traffic sign"
 msgid "Stop"
 msgstr "Stop"
@@ -445,7 +415,6 @@ msgstr "Odeslat sadu změn"
 msgid "Submit the current changeset"
 msgstr "Odeslat aktuální sadu změn"
 
-#. CHECKSTYLE.OFF: LineLength
 msgid "Submit the current changeset to Mapillary"
 msgstr "Odeslat aktuální sadu změn na Mapillary"
 
@@ -481,7 +450,6 @@ msgid "There are currently no layers with geotagged images!"
 msgstr ""
 "Momentálně nemáme žádné vrstvy s obrázky se zeměpisnými sourřadnicemi!"
 
-#, java-format
 msgid ""
 "To solve this problem, you could switch to download mode ''{0}'' and load "
 "Mapillary images for a smaller portion of the map."
@@ -499,11 +467,9 @@ msgid "Too many map objects, zoom in to see all."
 msgstr ""
 "Příliš mnoho mapových objektů, zvětšte přiblížení, abyste viděli všechny."
 
-#, java-format
 msgid "Total Mapillary images: {0}"
 msgstr "Celkem obrázků z Mapillary: {0}"
 
-#, java-format
 msgid "Turned {0} image"
 msgid_plural "Turned {0} images"
 msgstr[0] "Otočen {0} obrázek"
@@ -514,7 +480,6 @@ msgstr[3] "Otočeno {0} obrázků"
 msgid "Undo"
 msgstr "Zpět"
 
-#. i18n: traffic sign
 msgid "Uneven road"
 msgstr "Nerovnost vozovky"
 
@@ -527,11 +492,9 @@ msgstr "Nahrát na server obrázky Mapillary"
 msgid "Upload selected sequence"
 msgstr "Nahrát vybranou sekvenci"
 
-#, java-format
 msgid "Uploading: {0}"
 msgstr "Nahrávám na server: {0}"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Use 24 hour format"
 msgstr "Použít 24hodinový formát"
 
@@ -547,7 +510,6 @@ msgstr "Počkat na obrázek v maximální kvalitě"
 msgid "Walk mode"
 msgstr "Režim chůze"
 
-#. i18n: Checkbox label in JOSM settings
 msgid ""
 "When opening Mapillary image in web browser, show the blur editor instead of"
 " the image viewer"
@@ -564,7 +526,6 @@ msgstr "Let"
 msgid "You are currently not logged in."
 msgstr "Momentálně nejste přihlášen."
 
-#, java-format
 msgid "You are logged in as ''{0}''."
 msgstr "Jste přihlášen jako ''{0}''."
 
@@ -580,18 +541,15 @@ msgstr "Zvětšit na aktuálně zvolený obrázek Mapillary"
 msgid "approved"
 msgstr "schváleno"
 
-#. i18n: download mode for Mapillary images
 msgid "areas with downloaded OSM-data"
 msgstr "oblasti se staženými daty OSM"
 
-#. i18n: download mode for Mapillary images
 msgid "everything in the visible area"
 msgstr "vše ve viditelné oblasti"
 
 msgid "image has no key"
 msgstr "obrázek nemá žádný klíč"
 
-#. i18n: download mode for Mapillary images
 msgid "only when manually requested"
 msgstr "pouze pokud je ručně požadováno"
 
@@ -607,7 +565,6 @@ msgstr "sekvence nemá žádný klíč"
 msgid "unknown user"
 msgstr "neznámý uživatel"
 
-#, java-format
 msgid ""
 "{0}\n"
 "Could not read map objects from URL\n"
@@ -617,14 +574,11 @@ msgstr ""
 "Nelze načíst objekty mapy z URL\n"
 "{1}!"
 
-#, java-format
 msgid "{0} detections"
 msgstr "{0} detekcí"
 
-#, java-format
 msgid "{0} images in {1} sequences"
 msgstr "{0} obrázků ve {1} sekvencích"
 
-#. Plugin description for Mapillary
 msgid "Allows the user to work with pictures hosted at mapillary.com"
 msgstr "Dovoluje uživateli pracovat s obrázky uloženými na mapillary.com"

--- a/src/main/po/da.po
+++ b/src/main/po/da.po
@@ -1,15 +1,15 @@
 # Translations for the JOSM plugin 'Mapillary' (da)
-# Copyright (C) 2018 
+# Copyright (C) 2020
 # This file is distributed under the same license as the josm-plugin_Mapillary package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
-#, fuzzy
+#
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: josm-plugin_Mapillary v1.5.16-14-g82b2768\n"
+"Project-Id-Version: josm-plugin_Mapillary 1.5.20-3-ge40f8de\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-30 10:39+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"POT-Creation-Date: 2020-02-17 00:25+0000\n"
+"PO-Revision-Date: 2018-01-15 10:33+0000\n"
 "Language-Team: Danish (https://www.transifex.com/josm/teams/2544/da/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -23,7 +23,6 @@ msgstr "2 billeder lagt sammen"
 msgid "2 images unjoined"
 msgstr "2 billeder adskilt"
 
-#, java-format
 msgid ""
 "A tag with key <i>{0}</i> is already present on the selected OSM object."
 msgstr ""
@@ -52,7 +51,6 @@ msgstr ""
 msgid "Cancel"
 msgstr "Annuller"
 
-#, java-format
 msgid "Changeset upload failed with {0} error ''{1} {2}''!"
 msgstr "Rettesæt upload mislykkedes med {0} fejl ''{1} {2}''!"
 
@@ -68,26 +66,21 @@ msgstr "Kopier nøgle"
 msgid "Could not import a geotagged image to the Mapillary layer!"
 msgstr "Kunne ikke importere et geotagget billede til Mapillary laget!"
 
-#, java-format
 msgid "Could not import the directory ''{0}''!"
 msgstr "Kunne ikke importere mappen ''{0}''!"
 
-#, java-format
 msgid "Could not import the image ''{0}''!"
 msgstr "Kunne ikke importere billedet ''{0}''!"
 
-#, java-format
 msgid "Could not open the URL {0} in a browser"
 msgstr "Kunne ikke åbne URL {0} i en browser"
 
-#, java-format
 msgid "Could not read from URL {0}!"
 msgstr "Kunne ikke læse fra URL {0}!"
 
 msgid "Current Mapillary changeset"
 msgstr "Aktuelt Mapillary rettesæt"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Cut off sequences at download bounds"
 msgstr "Afskær sekvenser ved download grænse"
 
@@ -97,13 +90,11 @@ msgstr "Dage"
 msgid "Delete after upload"
 msgstr "Slet efter upload"
 
-#, java-format
 msgid "Deleted {0} image"
 msgid_plural "Deleted {0} images"
 msgstr[0] "Slettede {0} billede"
 msgstr[1] "Slettede {0} billeder"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Display hour when the picture was taken"
 msgstr "Vis hvornår billedet blev taget"
 
@@ -118,7 +109,6 @@ msgstr ""
 msgid "Displays the layer displaying the map objects detected by Mapillary"
 msgstr "Viser laget der viser de kortobjekter, der er fundet af Mapillary"
 
-#, java-format
 msgid ""
 "Do you really want to replace the current value <i>{0}</i> with the new "
 "value <i>{1}</i>?"
@@ -144,7 +134,6 @@ msgstr "Downloading af kortobjekter mislykkedes!"
 msgid "Downloading map objects…"
 msgstr "Downloader kortobjekter…"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Enable experimental beta-features (might be unstable)"
 msgstr "Aktiver eksperimentelle beta-funktioner (muligvis ustabil)"
 
@@ -175,7 +164,6 @@ msgstr "Fra eksisterende billedlag"
 msgid "From which source do you want to import images to the Mapillary layer?"
 msgstr "Fra hvilken kilde vil du importere billeder til Mapillary laget?"
 
-#. i18n: traffic sign
 msgid "Give way"
 msgstr "Ubetinget vigepligt"
 
@@ -221,13 +209,11 @@ msgstr "Importer billeder til Mapillary lag"
 msgid "Imported images"
 msgstr "Importerede billeder"
 
-#, java-format
 msgid "Imported {0} image"
 msgid_plural "Imported {0} images"
 msgstr[0] "Importerede {0} billede"
 msgstr[1] "Importerede {0} billeder"
 
-#. i18n: traffic sign
 msgid "Intersection danger"
 msgstr "Farligt vejkryds"
 
@@ -266,7 +252,6 @@ msgstr "Login lykkes, vend tilbage til JOSM."
 msgid "Logout"
 msgstr "Log ud"
 
-#. i18n: traffic sign
 msgid "Mandatory direction (any)"
 msgstr "Påbudt kørselsretning (enhver)"
 
@@ -303,7 +288,6 @@ msgstr "Mapillary objekter"
 msgid "Months"
 msgstr "Måneder"
 
-#, java-format
 msgid "Moved {0} image"
 msgid_plural "Moved {0} images"
 msgstr[0] "Flyttede {0} billede"
@@ -312,32 +296,24 @@ msgstr[1] "Flyttede {0} billeder"
 msgid "Next picture"
 msgstr "Næste billede"
 
-#. i18n: traffic sign
 msgid "No entry"
 msgstr "Indkørsel forbudt"
-
-msgid "No image selected"
-msgstr "Intet billede valgt"
 
 msgid "No images found"
 msgstr "Ingen billeder fundet"
 
-#. i18n: traffic sign
 msgid "No overtaking"
 msgstr "Overhaling forbudt"
 
-#. i18n: traffic sign
 msgid "No parking"
 msgstr "Parking forbudt"
 
-#. i18n: traffic sign
 msgid "No turn"
 msgstr "Sving forbudt"
 
 msgid "Not older than: "
 msgstr "Ikke ældre end: "
 
-#. i18n: Spinner label in JOSM settings
 msgid "Number of images to be pre-fetched (forwards and backwards)"
 msgstr "Antal billeder der skal hentes (frem og tilbage)"
 
@@ -365,18 +341,15 @@ msgstr "Pause"
 msgid "Pauses the walk."
 msgstr "Sætter gåturen på pause."
 
-#. i18n: traffic sign
 msgid "Pedestrian crossing"
 msgstr "Fodgængerfelt"
 
 msgid "Play"
 msgstr "Afspil"
 
-#, java-format
 msgid "Press \"{0}\" to download images"
 msgstr "Tryk \"{0}\" for at downloade billeder"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Preview images when hovering its icon"
 msgstr "Forhåndsvis billeder når markør er over dets ikon"
 
@@ -392,7 +365,6 @@ msgstr "Nulstil"
 msgid "Rewrite imported images"
 msgstr "Genskriv importerede billeder"
 
-#. i18n: traffic sign
 msgid "Roundabout"
 msgstr "Rundkørsel"
 
@@ -420,7 +392,6 @@ msgstr "Viser det næste billede i sekvensen"
 msgid "Shows the previous picture in the sequence"
 msgstr "Viser det forrige billede i sekvensen"
 
-#. i18n: traffic sign
 msgid "Speed limit"
 msgstr "Hastighedsbegrænsning"
 
@@ -428,7 +399,6 @@ msgctxt "as synonym to halt or stand still"
 msgid "Stop"
 msgstr "Stop"
 
-#. i18n: traffic sign
 msgctxt "name of the traffic sign"
 msgid "Stop"
 msgstr "Stop"
@@ -442,7 +412,6 @@ msgstr "Indsend rettesæt"
 msgid "Submit the current changeset"
 msgstr "Indsend det aktuelle rettesæt"
 
-#. CHECKSTYLE.OFF: LineLength
 msgid "Submit the current changeset to Mapillary"
 msgstr "Indsend det aktuelle rettesæt til Mapillary"
 
@@ -477,7 +446,6 @@ msgstr ""
 msgid "There are currently no layers with geotagged images!"
 msgstr "Der er i øjeblikket ingen lag med geotagged billeder!"
 
-#, java-format
 msgid ""
 "To solve this problem, you could switch to download mode ''{0}'' and load "
 "Mapillary images for a smaller portion of the map."
@@ -494,11 +462,9 @@ msgstr ""
 msgid "Too many map objects, zoom in to see all."
 msgstr "For mange kortobjekter, zoom ind for at se alle."
 
-#, java-format
 msgid "Total Mapillary images: {0}"
 msgstr "Total antal Mapillary billeder: {0}"
 
-#, java-format
 msgid "Turned {0} image"
 msgid_plural "Turned {0} images"
 msgstr[0] "Drejede {0} billede"
@@ -507,7 +473,6 @@ msgstr[1] "Drejede {0} billeder"
 msgid "Undo"
 msgstr "Fortryd"
 
-#. i18n: traffic sign
 msgid "Uneven road"
 msgstr "Ujævn vej"
 
@@ -520,11 +485,9 @@ msgstr "Upload Mapillary billeder"
 msgid "Upload selected sequence"
 msgstr "Upload valgt rækkefølge"
 
-#, java-format
 msgid "Uploading: {0}"
 msgstr "Uploader: {0}"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Use 24 hour format"
 msgstr "Brug 24-timers format"
 
@@ -540,7 +503,6 @@ msgstr "Vent på fuld kvalitets billeder"
 msgid "Walk mode"
 msgstr "Gå tilstand"
 
-#. i18n: Checkbox label in JOSM settings
 msgid ""
 "When opening Mapillary image in web browser, show the blur editor instead of"
 " the image viewer"
@@ -557,7 +519,6 @@ msgstr "År"
 msgid "You are currently not logged in."
 msgstr "Du er i øjeblikket ikke logget ind."
 
-#, java-format
 msgid "You are logged in as ''{0}''."
 msgstr "Du er logget ind som ''{0}''."
 
@@ -574,18 +535,15 @@ msgstr "Zoom til det aktuelt valgt Mapillary billede"
 msgid "approved"
 msgstr "godkendt"
 
-#. i18n: download mode for Mapillary images
 msgid "areas with downloaded OSM-data"
 msgstr "områder med downloadet OSM-data"
 
-#. i18n: download mode for Mapillary images
 msgid "everything in the visible area"
 msgstr "alt i det synlige område"
 
 msgid "image has no key"
 msgstr "Billedet har ingen nøgle"
 
-#. i18n: download mode for Mapillary images
 msgid "only when manually requested"
 msgstr "kun ved manuel anmodet"
 
@@ -601,7 +559,6 @@ msgstr "sekvens har ingen nøgle"
 msgid "unknown user"
 msgstr "ukendt bruger"
 
-#, java-format
 msgid ""
 "{0}\n"
 "Could not read map objects from URL\n"
@@ -611,14 +568,11 @@ msgstr ""
 "Kunne ikke læse kortobjekter fra URL\n"
 "{1}!"
 
-#, java-format
 msgid "{0} detections"
 msgstr "{0} detekteringer"
 
-#, java-format
 msgid "{0} images in {1} sequences"
 msgstr "{0} billeder i {1} sekvenser"
 
-#. Plugin description for Mapillary
 msgid "Allows the user to work with pictures hosted at mapillary.com"
 msgstr "Tillader brugeren at arbejde med billeder gemt på mapillary.com"

--- a/src/main/po/de.po
+++ b/src/main/po/de.po
@@ -1,15 +1,15 @@
 # Translations for the JOSM plugin 'Mapillary' (de)
-# Copyright (C) 2018 
+# Copyright (C) 2020
 # This file is distributed under the same license as the josm-plugin_Mapillary package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
-#, fuzzy
+#
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: josm-plugin_Mapillary v1.5.16-14-g82b2768\n"
+"Project-Id-Version: josm-plugin_Mapillary 1.5.20-3-ge40f8de\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-30 10:39+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"POT-Creation-Date: 2020-02-17 00:25+0000\n"
+"PO-Revision-Date: 2018-01-15 10:33+0000\n"
 "Language-Team: German (https://www.transifex.com/josm/teams/2544/de/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -23,7 +23,6 @@ msgstr "2 Bilder verbunden"
 msgid "2 images unjoined"
 msgstr "2 Bilder getrennt"
 
-#, java-format
 msgid ""
 "A tag with key <i>{0}</i> is already present on the selected OSM object."
 msgstr ""
@@ -54,14 +53,12 @@ msgstr ""
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#. i18n: Checkbox label in JOSM settings
 msgid ""
 "Center view on new image when using the buttons to jump to another image"
 msgstr ""
 "Zentriere Ansicht auf neuem Bild, wenn man per Knopfdruck zu einem anderen "
 "Bild wechselt"
 
-#, java-format
 msgid "Changeset upload failed with {0} error ''{1} {2}''!"
 msgstr "Hochladen des Änderungssatzes fehlgeschlagen mit {0} Fehler \"{1} {2}\"!"
 
@@ -78,28 +75,26 @@ msgid "Could not import a geotagged image to the Mapillary layer!"
 msgstr ""
 "Konnte ein georeferenziertes Bild nicht in die Mapillary-Ebene importieren!"
 
-#, java-format
 msgid "Could not import the directory ''{0}''!"
 msgstr "Verzeichnis ''{0}'' konnte nicht importiert werden!"
 
-#, java-format
 msgid "Could not import the image ''{0}''!"
 msgstr "Bild ''{0}'' konnte nicht importiert werden!"
 
-#, java-format
 msgid "Could not open the URL {0} in a browser"
 msgstr "Konnte die URL {0} nicht in einem Browser öffnen"
 
-#, java-format
 msgid "Could not read from URL {0}!"
 msgstr "Konnte nicht von URL {0} lesen!"
 
 msgid "Current Mapillary changeset"
 msgstr "Aktueller Mapillary-Änderungssatz"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Cut off sequences at download bounds"
 msgstr "Schneide Sequenzen an den Herunterladegrenzen ab"
+
+msgid "Dark mode for image display"
+msgstr "Dunkler Modus für die Anzeige der Bilder"
 
 msgid "Days"
 msgstr "Tage"
@@ -107,13 +102,11 @@ msgstr "Tage"
 msgid "Delete after upload"
 msgstr "Nach dem Hochladen löschen"
 
-#, java-format
 msgid "Deleted {0} image"
 msgid_plural "Deleted {0} images"
 msgstr[0] "{0} Bild gelöscht"
 msgstr[1] "{0} Bilder gelöscht"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Display hour when the picture was taken"
 msgstr "Stunde, in der das Bild gemacht wurde, anzeigen"
 
@@ -129,7 +122,6 @@ msgid "Displays the layer displaying the map objects detected by Mapillary"
 msgstr ""
 "Zeigt die Ebene an, welche von Mapillary erkannte Kartenobjekte darstellt"
 
-#, java-format
 msgid ""
 "Do you really want to replace the current value <i>{0}</i> with the new "
 "value <i>{1}</i>?"
@@ -158,7 +150,6 @@ msgstr "Kartenobjekte werden heruntergeladen …"
 msgid "Downloading…"
 msgstr "Wird heruntergeladen …"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Enable experimental beta-features (might be unstable)"
 msgstr "Experimentelle Beta-Funktionalität aktivieren (kann instabil sein)"
 
@@ -193,7 +184,6 @@ msgid "From which source do you want to import images to the Mapillary layer?"
 msgstr ""
 "Von welcher Quelle möchten Sie Bilder auf die Mapillary-Ebene importieren?"
 
-#. i18n: traffic sign
 msgid "Give way"
 msgstr "Vorfahrt gewähren"
 
@@ -241,13 +231,11 @@ msgstr "Bilder in Mapillary-Ebene importieren"
 msgid "Imported images"
 msgstr "Importierte Bilder"
 
-#, java-format
 msgid "Imported {0} image"
 msgid_plural "Imported {0} images"
 msgstr[0] "{0} Bild importiert"
 msgstr[1] "{0} Bilder importiert"
 
-#. i18n: traffic sign
 msgid "Intersection danger"
 msgstr "Gefährliche Kreuzung"
 
@@ -289,7 +277,6 @@ msgstr "Anmeldung erfolgreich, zurück zu JOSM."
 msgid "Logout"
 msgstr "Abmelden"
 
-#. i18n: traffic sign
 msgid "Mandatory direction (any)"
 msgstr "Vorgeschriebene Richtung (beliebig)"
 
@@ -326,7 +313,6 @@ msgstr "Mapillary-Objekte"
 msgid "Months"
 msgstr "Monate"
 
-#, java-format
 msgid "Moved {0} image"
 msgid_plural "Moved {0} images"
 msgstr[0] "{0} Bild verschoben"
@@ -335,25 +321,18 @@ msgstr[1] "{0} Bilder verschoben"
 msgid "Next picture"
 msgstr "Nächstes Bild"
 
-#. i18n: traffic sign
 msgid "No entry"
 msgstr "Einfahrt verboten"
-
-msgid "No image selected"
-msgstr "Kein Bild ausgewählt"
 
 msgid "No images found"
 msgstr "Keine Bilder gefunden"
 
-#. i18n: traffic sign
 msgid "No overtaking"
 msgstr "Überholverbot"
 
-#. i18n: traffic sign
 msgid "No parking"
 msgstr "Parkverbot"
 
-#. i18n: traffic sign
 msgid "No turn"
 msgstr "Abbiegen verboten"
 
@@ -363,7 +342,6 @@ msgstr "Nicht in Mapillary eingeloggt"
 msgid "Not older than: "
 msgstr "Nicht älter als: "
 
-#. i18n: Spinner label in JOSM settings
 msgid "Number of images to be pre-fetched (forwards and backwards)"
 msgstr "Anzahl der vorab abzurufenden Bilder (vorwärts und rückwärts)"
 
@@ -391,18 +369,15 @@ msgstr "Pause"
 msgid "Pauses the walk."
 msgstr "Pausiert den Spaziergang."
 
-#. i18n: traffic sign
 msgid "Pedestrian crossing"
 msgstr "Fußgängerübergang"
 
 msgid "Play"
 msgstr "Wiedergabe"
 
-#, java-format
 msgid "Press \"{0}\" to download images"
 msgstr "Zum Herunterladen von Bildern \"{0}\" drücken"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Preview images when hovering its icon"
 msgstr "Beim Überfahren des Symbols Vorschaubilder anzeigen"
 
@@ -418,7 +393,6 @@ msgstr "Zurücksetzen"
 msgid "Rewrite imported images"
 msgstr "Importierte Bilder neu schreiben"
 
-#. i18n: traffic sign
 msgid "Roundabout"
 msgstr "Kreisverkehr"
 
@@ -446,7 +420,6 @@ msgstr "Zeigt das nächste Bild in der Sequenz an"
 msgid "Shows the previous picture in the sequence"
 msgstr "Zeigt das vorherige Bild in der Sequenz an"
 
-#. i18n: traffic sign
 msgid "Speed limit"
 msgstr "Geschwindigkeitsbegrenzung"
 
@@ -454,7 +427,6 @@ msgctxt "as synonym to halt or stand still"
 msgid "Stop"
 msgstr "Anhalten"
 
-#. i18n: traffic sign
 msgctxt "name of the traffic sign"
 msgid "Stop"
 msgstr "Stoppschild"
@@ -468,7 +440,6 @@ msgstr "Änderungssatz absenden"
 msgid "Submit the current changeset"
 msgstr "Aktuellen Änderungssatz absenden"
 
-#. CHECKSTYLE.OFF: LineLength
 msgid "Submit the current changeset to Mapillary"
 msgstr "Aktuellen Änderungssatz zu Mapillary absenden"
 
@@ -504,7 +475,6 @@ msgstr ""
 msgid "There are currently no layers with geotagged images!"
 msgstr "There are currently no layers with geotagged images!"
 
-#, java-format
 msgid ""
 "To solve this problem, you could switch to download mode ''{0}'' and load "
 "Mapillary images for a smaller portion of the map."
@@ -521,11 +491,9 @@ msgstr ""
 msgid "Too many map objects, zoom in to see all."
 msgstr "Zu viele Kartenobjekte, vergrößern um alle zu sehen."
 
-#, java-format
 msgid "Total Mapillary images: {0}"
 msgstr "Mapillary-Bilder insgesamt: {0}"
 
-#, java-format
 msgid "Turned {0} image"
 msgid_plural "Turned {0} images"
 msgstr[0] "{0} Bild gedreht"
@@ -534,7 +502,6 @@ msgstr[1] "{0} Bilder gedreht"
 msgid "Undo"
 msgstr "Rückgängig"
 
-#. i18n: traffic sign
 msgid "Uneven road"
 msgstr "Unebene Fahrbahn"
 
@@ -547,11 +514,9 @@ msgstr "Bilder zu Mapillary hochladen"
 msgid "Upload selected sequence"
 msgstr "Ausgewählte Sequenz hochladen"
 
-#, java-format
 msgid "Uploading: {0}"
 msgstr "Hachladevorgang: {0}"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Use 24 hour format"
 msgstr "24-Stunden-Format verwenden"
 
@@ -572,7 +537,6 @@ msgstr ""
 "Spaziergangmodus: Es dauert zu lange, das nächste Bild zu laden! "
 "Spaziergangmodus wird geschlossen …"
 
-#. i18n: Checkbox label in JOSM settings
 msgid ""
 "When opening Mapillary image in web browser, show the blur editor instead of"
 " the image viewer"
@@ -589,7 +553,6 @@ msgstr "Jahre"
 msgid "You are currently not logged in."
 msgstr "Sie sind momentan nicht angemeldet."
 
-#, java-format
 msgid "You are logged in as ''{0}''."
 msgstr "Sie sind als ''{0}'' angemeldet."
 
@@ -598,7 +561,13 @@ msgstr ""
 "Sie sind nicht angemeldet, bitte melden Sie sich in den Einstellungen bei "
 "Mapillary an"
 
-#, java-format
+msgid ""
+"You are trying to upload a sequence to mapillary.com that you previously "
+"downloaded from there. That is not possible."
+msgstr ""
+"Du versuchst, eine Sequenz auf mapillary.com hochzuladen, die du vorher von "
+"dort heruntergeladen hast. Das ist nicht möglich."
+
 msgid "You have successfully uploaded {0} image to mapillary.com"
 msgid_plural "You have successfully uploaded {0} images to mapillary.com"
 msgstr[0] "{0} Bild wurde erfolgreich zu mapillary.com hochgeladen"
@@ -613,18 +582,18 @@ msgstr "Auf das aktuell ausgewählte Mapillary-Bild zoomen"
 msgid "approved"
 msgstr "genehmigt"
 
-#. i18n: download mode for Mapillary images
 msgid "areas with downloaded OSM-data"
 msgstr "Gebiete mit heruntergeladenen OSM-Daten"
 
-#. i18n: download mode for Mapillary images
 msgid "everything in the visible area"
 msgstr "alles im sichtbaren Bereich"
 
 msgid "image has no key"
 msgstr "Bild hat keinen Schlüssel"
 
-#. i18n: download mode for Mapillary images
+msgid "no image selected"
+msgstr "kein Bild ausgewählt"
+
 msgid "only when manually requested"
 msgstr "nur wenn manuell angefordert"
 
@@ -640,7 +609,6 @@ msgstr "Sequenz hat keinen Schlüssel"
 msgid "unknown user"
 msgstr "unbekannter Nutzer"
 
-#, java-format
 msgid ""
 "{0}\n"
 "Could not read map objects from URL\n"
@@ -651,30 +619,24 @@ msgstr ""
 "{1}\n"
 "gelesen werden!"
 
-#. i18n: {0} is the layer name, {1} the number of images in it
-#, java-format
 msgid "{0} ({1} image)"
 msgid_plural "{0} ({1} images)"
 msgstr[0] "{0} ({1} Bild)"
 msgstr[1] "{0} ({1} Bilder)"
 
-#, java-format
 msgid "{0} detections"
 msgstr "{0} Erkennungen"
 
-#, java-format
 msgid "{0} downloaded image"
 msgid_plural "{0} downloaded images"
 msgstr[0] "{0} heruntergeladenes Bild"
 msgstr[1] "{0} heruntergeladene Bilder"
 
-#, java-format
 msgid "{0} image in total"
 msgid_plural "{0} images in total"
 msgstr[0] "{0} Bild insgesamt"
 msgstr[1] "{0} Bilder insgesamt"
 
-#, java-format
 msgid "{0} image submitted, Changeset key: {1}, State: {2}"
 msgid_plural "{0} images submitted, Changeset key: {1}, State: {2}"
 msgstr[0] ""
@@ -682,24 +644,20 @@ msgstr[0] ""
 msgstr[1] ""
 "{0} Bilder eingereicht, Schlüssel des Änderungssatzes: {1}, Status: {2}"
 
-#, java-format
 msgid "{0} images in {1} sequences"
 msgstr "{0} Bilder in {1} Sequenzen"
 
-#, java-format
 msgid "{0} imported image"
 msgid_plural "{0} imported images"
 msgstr[0] "{0} importiertes Bild"
 msgstr[1] "{0} importierte Bilder"
 
-#, java-format
 msgid "{0} sequence, containing between {1} and {2} images (ø {3})"
 msgid_plural ""
 "{0} sequences, each containing between {1} and {2} images (ø {3})"
 msgstr[0] "{0} Sequenz, sie beinhaltet zwischen {1} und {2} Bilder (ø {3})"
 msgstr[1] "{0} Sequenzen, jede beinhaltet zwischen {1} und {2} Bilder (ø {3})"
 
-#. Plugin description for Mapillary
 msgid "Allows the user to work with pictures hosted at mapillary.com"
 msgstr ""
 "Ermöglicht dem Benutzer das Arbeiten mit von mapillary.com bereitgestellten "

--- a/src/main/po/el.po
+++ b/src/main/po/el.po
@@ -1,15 +1,15 @@
 # Translations for the JOSM plugin 'Mapillary' (el)
-# Copyright (C) 2018 
+# Copyright (C) 2020
 # This file is distributed under the same license as the josm-plugin_Mapillary package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
-#, fuzzy
+#
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: josm-plugin_Mapillary v1.5.16-14-g82b2768\n"
+"Project-Id-Version: josm-plugin_Mapillary 1.5.20-3-ge40f8de\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-30 10:39+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"POT-Creation-Date: 2020-02-17 00:25+0000\n"
+"PO-Revision-Date: 2018-01-15 10:33+0000\n"
 "Language-Team: Greek (https://www.transifex.com/josm/teams/2544/el/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -23,7 +23,6 @@ msgstr "2 εικόνες συνδέθηκαν"
 msgid "2 images unjoined"
 msgstr "2 εικόνες αποσυνδέθηκαν"
 
-#, java-format
 msgid ""
 "A tag with key <i>{0}</i> is already present on the selected OSM object."
 msgstr ""
@@ -54,7 +53,12 @@ msgstr ""
 msgid "Cancel"
 msgstr "Ακύρωση"
 
-#, java-format
+msgid ""
+"Center view on new image when using the buttons to jump to another image"
+msgstr ""
+"Κεντράρισμα προβολής σε νέα εικόνα όταν χρησιμοποιείτε τα κουμπιά για να "
+"μεταβείτε σε άλλη εικόνα"
+
 msgid "Changeset upload failed with {0} error ''{1} {2}''!"
 msgstr "Η μεταφόρτωση του πακέτου αλλαγών απέτυχε με {0} σφάλμα ''{1} {2}''!"
 
@@ -72,27 +76,22 @@ msgstr ""
 "Δεν ήταν δυνατή η εισαγωγή μιας γεωαναφερμένης εικόνας στο επίπεδο του "
 "Mapillary!"
 
-#, java-format
 msgid "Could not import the directory ''{0}''!"
 msgstr "Δεν ήταν δυνατή η εισαγωγή του καταλόγου ''{0}''!"
 
-#, java-format
 msgid "Could not import the image ''{0}''!"
 msgstr "Δεν ήταν δυνατή η εισαγωγή της εικόνας ''{0}''!"
 
-#, java-format
 msgid "Could not open the URL {0} in a browser"
 msgstr ""
 "Δεν είναι δυνατό να ανοίξει η διεύθυνση {0} σε ένα πρόγραμμα περιήγησης"
 
-#, java-format
 msgid "Could not read from URL {0}!"
 msgstr "Δεν ήταν δυνατή η ανάγνωση από τη διεύθυνση {0}!"
 
 msgid "Current Mapillary changeset"
 msgstr "Τωρινό πακέτο αλλαγών Mapillary"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Cut off sequences at download bounds"
 msgstr "Αποκοπή διαδοχής στα όρια λήψης"
 
@@ -102,7 +101,6 @@ msgstr "Ημέρες"
 msgid "Delete after upload"
 msgstr "Διαγραφή μετά την μεταφόρτωση"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Display hour when the picture was taken"
 msgstr "Εμφάνιση ώρας κατά την λήψη της φωτογραφίας"
 
@@ -121,7 +119,6 @@ msgstr ""
 "Εμφάνιση του επιπέδου που εμφανίζει τα αντικείμενα χάρτη που ανιχνεύονται "
 "από το Mapillary"
 
-#, java-format
 msgid ""
 "Do you really want to replace the current value <i>{0}</i> with the new "
 "value <i>{1}</i>?"
@@ -150,7 +147,6 @@ msgstr "Λήψη αντικειμένων χάρτη..."
 msgid "Downloading…"
 msgstr "Λήψη..."
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Enable experimental beta-features (might be unstable)"
 msgstr ""
 "Ενεργοποίηση πειραματικών χαρακτηριστικών beta (μπορεί να είναι ασταθής)"
@@ -228,7 +224,6 @@ msgstr "Εισαγωγή εικόνων στο επίπεδο Mapillary"
 msgid "Imported images"
 msgstr "Εισαγόμενες εικόνες"
 
-#. i18n: traffic sign
 msgid "Intersection danger"
 msgstr "Κίνδυνος διασταύρωσης"
 
@@ -270,7 +265,6 @@ msgstr "Επιτυχής σύνδεση, επιστρέψτε στο JOSM."
 msgid "Logout"
 msgstr "Αποσύνδεση"
 
-#. i18n: traffic sign
 msgid "Mandatory direction (any)"
 msgstr "Υποχρεωτική κατεύθυνση (οποιαδήποτε)"
 
@@ -310,32 +304,27 @@ msgstr "Μήνες"
 msgid "Next picture"
 msgstr "Επόμενη εικόνα"
 
-#. i18n: traffic sign
 msgid "No entry"
 msgstr "Απαγορεύεται η είσοδος"
-
-msgid "No image selected"
-msgstr "Δεν επιλέχθηκε εικόνα"
 
 msgid "No images found"
 msgstr "Δεν βρέθηκαν εικόνες"
 
-#. i18n: traffic sign
 msgid "No overtaking"
 msgstr "Απαγορεύεται η προσπέραση"
 
-#. i18n: traffic sign
 msgid "No parking"
 msgstr "Απαγορεύεται η στάθμευση"
 
-#. i18n: traffic sign
 msgid "No turn"
 msgstr "Απαγορεύεται η στροφή"
+
+msgid "Not logged in to Mapillary"
+msgstr "Δεν έχετε συνδεθεί στο Mapillary"
 
 msgid "Not older than: "
 msgstr "Δεν είναι παλαιότερο από:"
 
-#. i18n: Spinner label in JOSM settings
 msgid "Number of images to be pre-fetched (forwards and backwards)"
 msgstr ""
 "Αριθμός εικόνων που πρέπει να προωθηθούν (προς τα εμπρός και προς τα πίσω)"
@@ -364,18 +353,15 @@ msgstr "Παύση"
 msgid "Pauses the walk."
 msgstr "Παύση του περίπατου."
 
-#. i18n: traffic sign
 msgid "Pedestrian crossing"
 msgstr "Διάβαση πεζών"
 
 msgid "Play"
 msgstr "Παίξε"
 
-#, java-format
 msgid "Press \"{0}\" to download images"
 msgstr "Πατήστε \"{0}\" για λήψη εικόνων"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Preview images when hovering its icon"
 msgstr "Προεπισκόπηση των εικόνων όταν εμφανίζεται το εικονίδιό τους"
 
@@ -391,7 +377,6 @@ msgstr "Μηδενισμός"
 msgid "Rewrite imported images"
 msgstr "Ξαναγράψτε τις εισαγόμενες εικόνες"
 
-#. i18n: traffic sign
 msgid "Roundabout"
 msgstr "Κυκλικός κόμβος"
 
@@ -419,7 +404,6 @@ msgstr "Εμφάνιση της επόμενης εικόνας στην σει�
 msgid "Shows the previous picture in the sequence"
 msgstr "Εμφάνιση της προηγούμενης εικόνας στην σειρά"
 
-#. i18n: traffic sign
 msgid "Speed limit"
 msgstr "Οριο ταχύτητας"
 
@@ -427,7 +411,6 @@ msgctxt "as synonym to halt or stand still"
 msgid "Stop"
 msgstr "Stop"
 
-#. i18n: traffic sign
 msgctxt "name of the traffic sign"
 msgid "Stop"
 msgstr "Stop"
@@ -441,7 +424,6 @@ msgstr "Υποβολή πακέτου αλλαγών"
 msgid "Submit the current changeset"
 msgstr "Υποβολή του τρέχοντος πακέτου αλλαγών"
 
-#. CHECKSTYLE.OFF: LineLength
 msgid "Submit the current changeset to Mapillary"
 msgstr "Υποβολή του τρέχοντος πακέτου αλλαγών στο Mapillary"
 
@@ -477,7 +459,6 @@ msgstr ""
 msgid "There are currently no layers with geotagged images!"
 msgstr "Αυτήν τη στιγμή δεν υπάρχουν επίπεδα με γεωαναφερμένες εικόνες!"
 
-#, java-format
 msgid ""
 "To solve this problem, you could switch to download mode ''{0}'' and load "
 "Mapillary images for a smaller portion of the map."
@@ -495,14 +476,12 @@ msgstr ""
 msgid "Too many map objects, zoom in to see all."
 msgstr "Πάρα πολλά αντικείμενα χάρτη, μεγεθύνετε για να τα δείτε όλα."
 
-#, java-format
 msgid "Total Mapillary images: {0}"
 msgstr "Σύνολο εικόνων Mapillary: {0}"
 
 msgid "Undo"
 msgstr "Αναίρεση"
 
-#. i18n: traffic sign
 msgid "Uneven road"
 msgstr "Ανώμαλος δρόμος"
 
@@ -515,11 +494,9 @@ msgstr "Μεταφόρτωση εικόνων Mapillary"
 msgid "Upload selected sequence"
 msgstr "Μεταφόρτωση επιλεγμένης σειράς"
 
-#, java-format
 msgid "Uploading: {0}"
 msgstr "Μεταφόρτωση: {0}"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Use 24 hour format"
 msgstr "Χρησιμοποιήστε τη μορφή 24 ωρών"
 
@@ -549,7 +526,6 @@ msgstr "Έτος"
 msgid "You are currently not logged in."
 msgstr "Αυτή την στιγμή δεν έχετε συνδεθεί."
 
-#, java-format
 msgid "You are logged in as ''{0}''."
 msgstr "Έχετε συνδεθεί ως ''{0}''."
 
@@ -566,15 +542,15 @@ msgstr "Μεγέθυνση στη τρέχουσα επιλεγμένη εικό
 msgid "approved"
 msgstr "Εγκρίνεται"
 
-#. i18n: download mode for Mapillary images
 msgid "areas with downloaded OSM-data"
 msgstr "περιοχές με ληφθέντα δεδομένα OSM"
 
-#. i18n: download mode for Mapillary images
 msgid "everything in the visible area"
 msgstr "όλα στην ορατή περιοχή"
 
-#. i18n: download mode for Mapillary images
+msgid "image has no key"
+msgstr "η εικόνα δεν έχει κανένα κλειδί"
+
 msgid "only when manually requested"
 msgstr "μόνο όταν ζητηθεί χειροκίνητα"
 
@@ -584,10 +560,12 @@ msgstr "εκκρεμεί"
 msgid "rejected"
 msgstr "Απορρίπτεται"
 
+msgid "sequence has no key"
+msgstr "η ακολουθία δεν έχει κανένα κλειδί"
+
 msgid "unknown user"
 msgstr "Αγνωστος χρήστης"
 
-#, java-format
 msgid ""
 "{0}\n"
 "Could not read map objects from URL\n"
@@ -597,15 +575,12 @@ msgstr ""
 "Αδυύατη η ανάγνωση αντικειμένων χάρτη από τη διεύθυνση\n"
 "{1}!"
 
-#, java-format
 msgid "{0} detections"
 msgstr "{0} ανακαλύψεις"
 
-#, java-format
 msgid "{0} images in {1} sequences"
 msgstr "{0} εικόνες σε {1} ακολουθίες"
 
-#. Plugin description for Mapillary
 msgid "Allows the user to work with pictures hosted at mapillary.com"
 msgstr ""
 "Επιτρέπεται στον χρήστη να δουλεύει με εικόνες που φιλοξενούνται στο "

--- a/src/main/po/en_GB.po
+++ b/src/main/po/en_GB.po
@@ -1,15 +1,15 @@
 # Translations for the JOSM plugin 'Mapillary' (en_GB)
-# Copyright (C) 2018 
+# Copyright (C) 2020
 # This file is distributed under the same license as the josm-plugin_Mapillary package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
-#, fuzzy
+#
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: josm-plugin_Mapillary v1.5.16-14-g82b2768\n"
+"Project-Id-Version: josm-plugin_Mapillary 1.5.20-3-ge40f8de\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-30 10:39+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"POT-Creation-Date: 2020-02-17 00:25+0000\n"
+"PO-Revision-Date: 2018-01-15 10:33+0000\n"
 "Language-Team: English (United Kingdom) (https://www.transifex.com/josm/teams/2544/en_GB/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -41,13 +41,11 @@ msgstr "Days"
 msgid "Delete after upload"
 msgstr "Delete after upload"
 
-#, java-format
 msgid "Deleted {0} image"
 msgid_plural "Deleted {0} images"
 msgstr[0] "Deleted {0} image"
 msgstr[1] "Deleted {0} images"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Display hour when the picture was taken"
 msgstr "Display hour when the picture was taken"
 
@@ -81,7 +79,6 @@ msgstr "Finished upload"
 msgid "Follow selected image"
 msgstr "Follow selected image"
 
-#. i18n: traffic sign
 msgid "Give way"
 msgstr "Give way"
 
@@ -106,13 +103,11 @@ msgstr "Import pictures into Mapillary layer"
 msgid "Imported images"
 msgstr "Imported images"
 
-#, java-format
 msgid "Imported {0} image"
 msgid_plural "Imported {0} images"
 msgstr[0] "Imported {0} image"
 msgstr[1] "Imported {0} images"
 
-#. i18n: traffic sign
 msgid "Intersection danger"
 msgstr "Intersection danger"
 
@@ -143,7 +138,6 @@ msgstr "Login successful, return to JOSM."
 msgid "Logout"
 msgstr "Logout"
 
-#. i18n: traffic sign
 msgid "Mandatory direction (any)"
 msgstr "Mandatory direction (any)"
 
@@ -171,7 +165,6 @@ msgstr "Mapillary login"
 msgid "Months"
 msgstr "Months"
 
-#, java-format
 msgid "Moved {0} image"
 msgid_plural "Moved {0} images"
 msgstr[0] "Moved {0} image"
@@ -180,25 +173,18 @@ msgstr[1] "Moved {0} images"
 msgid "Next picture"
 msgstr "Next picture"
 
-#. i18n: traffic sign
 msgid "No entry"
 msgstr "No entry"
-
-msgid "No image selected"
-msgstr "No image selected"
 
 msgid "No images found"
 msgstr "No images found"
 
-#. i18n: traffic sign
 msgid "No overtaking"
 msgstr "No overtaking"
 
-#. i18n: traffic sign
 msgid "No parking"
 msgstr "No parking"
 
-#. i18n: traffic sign
 msgid "No turn"
 msgstr "No turn"
 
@@ -226,14 +212,12 @@ msgstr "Pause"
 msgid "Pauses the walk."
 msgstr "Pauses the walk."
 
-#. i18n: traffic sign
 msgid "Pedestrian crossing"
 msgstr "Pedestrian crossing"
 
 msgid "Play"
 msgstr "Play"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Preview images when hovering its icon"
 msgstr "Preview images when hovering its icon"
 
@@ -249,7 +233,6 @@ msgstr "Reset"
 msgid "Rewrite imported images"
 msgstr "Rewrite imported images"
 
-#. i18n: traffic sign
 msgid "Roundabout"
 msgstr "Roundabout"
 
@@ -265,7 +248,6 @@ msgstr "Shows the next picture in the sequence"
 msgid "Shows the previous picture in the sequence"
 msgstr "Shows the previous picture in the sequence"
 
-#. i18n: traffic sign
 msgid "Speed limit"
 msgstr "Speed limit"
 
@@ -273,7 +255,6 @@ msgctxt "as synonym to halt or stand still"
 msgid "Stop"
 msgstr "Stop"
 
-#. i18n: traffic sign
 msgctxt "name of the traffic sign"
 msgid "Stop"
 msgstr "Stop"
@@ -287,7 +268,6 @@ msgstr "Submit changeset"
 msgid "Submit the current changeset"
 msgstr "Submit the current changeset"
 
-#. CHECKSTYLE.OFF: LineLength
 msgid "Submit the current changeset to Mapillary"
 msgstr "Submit the current changeset to Mapillary"
 
@@ -297,11 +277,9 @@ msgstr "Submitting Mapillary Changeset"
 msgid "Supported image formats (JPG and PNG)"
 msgstr "Supported image formats (JPG and PNG)"
 
-#, java-format
 msgid "Total Mapillary images: {0}"
 msgstr "Total Mapillary images: {0}"
 
-#, java-format
 msgid "Turned {0} image"
 msgid_plural "Turned {0} images"
 msgstr[0] "Turned {0} image"
@@ -310,7 +288,6 @@ msgstr[1] "Turned {0} images"
 msgid "Undo"
 msgstr "Undo"
 
-#. i18n: traffic sign
 msgid "Uneven road"
 msgstr "Uneven road"
 
@@ -320,11 +297,9 @@ msgstr "Update"
 msgid "Upload selected sequence"
 msgstr "Upload selected sequence"
 
-#, java-format
 msgid "Uploading: {0}"
 msgstr "Uploading: {0}"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Use 24 hour format"
 msgstr "Use 24 hour format"
 
@@ -343,7 +318,6 @@ msgstr "Years"
 msgid "You are currently not logged in."
 msgstr "You are currently not logged in."
 
-#, java-format
 msgid "You are logged in as ''{0}''."
 msgstr "You are logged in as ''{0}''."
 
@@ -356,21 +330,17 @@ msgstr "Zoom to selected image"
 msgid "Zoom to the currently selected Mapillary image"
 msgstr "Zoom to the currently selected Mapillary image"
 
-#. i18n: download mode for Mapillary images
 msgid "areas with downloaded OSM-data"
 msgstr "areas with downloaded OSM-data"
 
-#. i18n: download mode for Mapillary images
 msgid "everything in the visible area"
 msgstr "everything in the visible area"
 
-#. i18n: download mode for Mapillary images
 msgid "only when manually requested"
 msgstr "only when manually requested"
 
 msgid "pending"
 msgstr "pending"
 
-#. Plugin description for Mapillary
 msgid "Allows the user to work with pictures hosted at mapillary.com"
 msgstr "Allows the user to work with pictures hosted at mapillary.com"

--- a/src/main/po/es.po
+++ b/src/main/po/es.po
@@ -1,15 +1,15 @@
 # Translations for the JOSM plugin 'Mapillary' (es)
-# Copyright (C) 2018 
+# Copyright (C) 2020
 # This file is distributed under the same license as the josm-plugin_Mapillary package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
-#, fuzzy
+#
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: josm-plugin_Mapillary v1.5.16-14-g82b2768\n"
+"Project-Id-Version: josm-plugin_Mapillary 1.5.20-3-ge40f8de\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-30 10:39+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"POT-Creation-Date: 2020-02-17 00:25+0000\n"
+"PO-Revision-Date: 2018-01-15 10:33+0000\n"
 "Language-Team: Spanish (https://www.transifex.com/josm/teams/2544/es/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -23,7 +23,6 @@ msgstr "2 imágenes unidas"
 msgid "2 images unjoined"
 msgstr "2 imágenes  separadas"
 
-#, java-format
 msgid ""
 "A tag with key <i>{0}</i> is already present on the selected OSM object."
 msgstr ""
@@ -53,7 +52,12 @@ msgstr ""
 msgid "Cancel"
 msgstr "Cancelar"
 
-#, java-format
+msgid ""
+"Center view on new image when using the buttons to jump to another image"
+msgstr ""
+"Centre la vista en la nueva imagen cuando usa los botones para saltar a otra"
+" imagen"
+
 msgid "Changeset upload failed with {0} error ''{1} {2}''!"
 msgstr "¡El conjunto de cambios  subido falló con {0} errores ''{1} {2}''!"
 
@@ -69,28 +73,26 @@ msgstr "Copiar clave"
 msgid "Could not import a geotagged image to the Mapillary layer!"
 msgstr "¡No se pudo importar una imagen geoetiquetada a la capa Mapillary!"
 
-#, java-format
 msgid "Could not import the directory ''{0}''!"
 msgstr "¡No se pudo importar el directorio ''{0}''!"
 
-#, java-format
 msgid "Could not import the image ''{0}''!"
 msgstr "¡No se pudo importar la imagen ''{0}''!"
 
-#, java-format
 msgid "Could not open the URL {0} in a browser"
 msgstr "No se pudo abrir la URL {0} en un navegador"
 
-#, java-format
 msgid "Could not read from URL {0}!"
 msgstr "¡No se pudo leer desde la URL {0}!"
 
 msgid "Current Mapillary changeset"
 msgstr "Conjunto de cambios de Mapillary actual"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Cut off sequences at download bounds"
 msgstr "Corta las secuencias en los límites de descargas"
+
+msgid "Dark mode for image display"
+msgstr "Modo oscuro para visualización de imágenes"
 
 msgid "Days"
 msgstr "Días"
@@ -98,13 +100,11 @@ msgstr "Días"
 msgid "Delete after upload"
 msgstr "Eliminar después de subir"
 
-#, java-format
 msgid "Deleted {0} image"
 msgid_plural "Deleted {0} images"
 msgstr[0] "Eliminada {0} imágen"
 msgstr[1] "Eliminadas {0} imágenes"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Display hour when the picture was taken"
 msgstr "Mostrar la hora de cuando la fotografía fue tomada."
 
@@ -122,7 +122,6 @@ msgstr ""
 "Muestra la capa donde se visualiza los objetos de mapa detectados por "
 "Mapillary"
 
-#, java-format
 msgid ""
 "Do you really want to replace the current value <i>{0}</i> with the new "
 "value <i>{1}</i>?"
@@ -151,7 +150,6 @@ msgstr "Descargando objetos de mapas..."
 msgid "Downloading…"
 msgstr "Descargando... "
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Enable experimental beta-features (might be unstable)"
 msgstr ""
 "Permitir características beta experimentales (podría comportarse de forma "
@@ -187,7 +185,6 @@ msgstr "Desde una capa de imágenes existente"
 msgid "From which source do you want to import images to the Mapillary layer?"
 msgstr "¿Desde qué origen desea importar las imágenes a la capa Mapillary?"
 
-#. i18n: traffic sign
 msgid "Give way"
 msgstr "Ceda el paso"
 
@@ -234,13 +231,11 @@ msgstr "Importar imágenes a la capa de Mapillary"
 msgid "Imported images"
 msgstr "Imágenes importadas"
 
-#, java-format
 msgid "Imported {0} image"
 msgid_plural "Imported {0} images"
 msgstr[0] "Importada {0} imágen"
 msgstr[1] "Importadas {0} imágenes"
 
-#. i18n: traffic sign
 msgid "Intersection danger"
 msgstr "Peligro por intersección"
 
@@ -282,7 +277,6 @@ msgstr "Acceso correcto, volver a JOSM."
 msgid "Logout"
 msgstr "Cerrar sesión"
 
-#. i18n: traffic sign
 msgid "Mandatory direction (any)"
 msgstr "Dirección obligatoria (cualquiera)"
 
@@ -319,7 +313,6 @@ msgstr "Objetos Mapillary"
 msgid "Months"
 msgstr "Meses"
 
-#, java-format
 msgid "Moved {0} image"
 msgid_plural "Moved {0} images"
 msgstr[0] "{0} imagen movida"
@@ -328,32 +321,27 @@ msgstr[1] "{0} imágenes movidas"
 msgid "Next picture"
 msgstr "Fotografía siguiente"
 
-#. i18n: traffic sign
 msgid "No entry"
 msgstr "Ninguna entrada"
-
-msgid "No image selected"
-msgstr "Ninguna imagen seleccionada"
 
 msgid "No images found"
 msgstr "No se encontraron las imágenes"
 
-#. i18n: traffic sign
 msgid "No overtaking"
 msgstr "No rebasar"
 
-#. i18n: traffic sign
 msgid "No parking"
 msgstr "No estacionarse"
 
-#. i18n: traffic sign
 msgid "No turn"
 msgstr "No gire"
+
+msgid "Not logged in to Mapillary"
+msgstr "No ha iniciado sesión en Mapillary"
 
 msgid "Not older than: "
 msgstr "No más antiguas que: "
 
-#. i18n: Spinner label in JOSM settings
 msgid "Number of images to be pre-fetched (forwards and backwards)"
 msgstr "Número de imágenes a ser pre-cargadas (adelante y hacia atrás)"
 
@@ -381,18 +369,15 @@ msgstr "Pausar"
 msgid "Pauses the walk."
 msgstr "Pausar la caminata."
 
-#. i18n: traffic sign
 msgid "Pedestrian crossing"
 msgstr "Cruce de peatones"
 
 msgid "Play"
 msgstr "Iniciar"
 
-#, java-format
 msgid "Press \"{0}\" to download images"
 msgstr "Oprima \"{0}\" para descargar imágenes"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Preview images when hovering its icon"
 msgstr "Vista previa de imágenes cuando el cursor se sitúa sobre el icono"
 
@@ -408,7 +393,6 @@ msgstr "Reiniciar"
 msgid "Rewrite imported images"
 msgstr "Reescribir las imágenes importadas"
 
-#. i18n: traffic sign
 msgid "Roundabout"
 msgstr "Rotonda"
 
@@ -436,7 +420,6 @@ msgstr "Mostrar la imagen siguiente de la secuencia"
 msgid "Shows the previous picture in the sequence"
 msgstr "Mostrar la imagen previa de la secuencia"
 
-#. i18n: traffic sign
 msgid "Speed limit"
 msgstr "Límite de velocidad"
 
@@ -444,7 +427,6 @@ msgctxt "as synonym to halt or stand still"
 msgid "Stop"
 msgstr "Stop"
 
-#. i18n: traffic sign
 msgctxt "name of the traffic sign"
 msgid "Stop"
 msgstr "Stop"
@@ -458,7 +440,6 @@ msgstr "Enviar conjunto de cambios"
 msgid "Submit the current changeset"
 msgstr "Enviar el conjunto de cambios actual"
 
-#. CHECKSTYLE.OFF: LineLength
 msgid "Submit the current changeset to Mapillary"
 msgstr "Enviar el conjunto de cambios actual a Mapillary"
 
@@ -493,7 +474,6 @@ msgstr ""
 msgid "There are currently no layers with geotagged images!"
 msgstr "¡Actualmente no hay acapas con imágenes geoetiquetadas!"
 
-#, java-format
 msgid ""
 "To solve this problem, you could switch to download mode ''{0}'' and load "
 "Mapillary images for a smaller portion of the map."
@@ -511,11 +491,9 @@ msgid "Too many map objects, zoom in to see all."
 msgstr ""
 "Demasiados objetos de mapa, realice un acercamiento para verlos a todos"
 
-#, java-format
 msgid "Total Mapillary images: {0}"
 msgstr "Imágenes de Mapillary totales: {0}"
 
-#, java-format
 msgid "Turned {0} image"
 msgid_plural "Turned {0} images"
 msgstr[0] "{0} imagen girada"
@@ -524,7 +502,6 @@ msgstr[1] "{0} imágenes giradas"
 msgid "Undo"
 msgstr "Deshacer"
 
-#. i18n: traffic sign
 msgid "Uneven road"
 msgstr "Camino irregular"
 
@@ -537,11 +514,9 @@ msgstr "Subir imágenes Mapillary"
 msgid "Upload selected sequence"
 msgstr "Subir secuencia seleccionada"
 
-#, java-format
 msgid "Uploading: {0}"
 msgstr "Cargando: {0}"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Use 24 hour format"
 msgstr "Usar formato de 24 horas."
 
@@ -562,7 +537,6 @@ msgstr ""
 "Modo caminata: ¡Se esta tardando demasiado en obtener la imagen siguiente! "
 "Saliendo del modo caminata..."
 
-#. i18n: Checkbox label in JOSM settings
 msgid ""
 "When opening Mapillary image in web browser, show the blur editor instead of"
 " the image viewer"
@@ -579,7 +553,6 @@ msgstr "Años"
 msgid "You are currently not logged in."
 msgstr "Actualmente no se encuentra registrado"
 
-#, java-format
 msgid "You are logged in as ''{0}''."
 msgstr "Está registrado como ''{0}''."
 
@@ -587,7 +560,13 @@ msgid "You are not logged in, please log in to Mapillary in the preferences"
 msgstr ""
 "No se ha validado. Por favor, inicie sesión de Mapillary en Preferencias"
 
-#, java-format
+msgid ""
+"You are trying to upload a sequence to mapillary.com that you previously "
+"downloaded from there. That is not possible."
+msgstr ""
+"Está intentando cargar una secuencia en mapillary.com que descargó "
+"anteriormente desde allí. Eso no es posible."
+
 msgid "You have successfully uploaded {0} image to mapillary.com"
 msgid_plural "You have successfully uploaded {0} images to mapillary.com"
 msgstr[0] "Subio {0} imágen a mapillary.com exitosamente"
@@ -602,18 +581,18 @@ msgstr "Acercar a la imagen seleccionada de Mapillary"
 msgid "approved"
 msgstr "aprobado"
 
-#. i18n: download mode for Mapillary images
 msgid "areas with downloaded OSM-data"
 msgstr "áreas con datos OSM descargados"
 
-#. i18n: download mode for Mapillary images
 msgid "everything in the visible area"
 msgstr "todo en la zona visible"
 
 msgid "image has no key"
 msgstr "la imagen no tiene clave"
 
-#. i18n: download mode for Mapillary images
+msgid "no image selected"
+msgstr "Ninguna imagen seleccionada"
+
 msgid "only when manually requested"
 msgstr "sólo cuando se solicitan manualmente"
 
@@ -629,7 +608,6 @@ msgstr "la secuencia no tiene clave"
 msgid "unknown user"
 msgstr "usuario desconocido"
 
-#, java-format
 msgid ""
 "{0}\n"
 "Could not read map objects from URL\n"
@@ -639,46 +617,43 @@ msgstr ""
 "No se pudo leer objetos del mapa desde la URL\n"
 "{1}!"
 
-#. i18n: {0} is the layer name, {1} the number of images in it
-#, java-format
 msgid "{0} ({1} image)"
 msgid_plural "{0} ({1} images)"
 msgstr[0] "{0} ({1} imagen)"
 msgstr[1] "{0} ({1} imagenes)"
 
-#, java-format
 msgid "{0} detections"
 msgstr "{0} detecciones"
 
-#, java-format
 msgid "{0} downloaded image"
 msgid_plural "{0} downloaded images"
 msgstr[0] "{0}  imagen descargada"
 msgstr[1] "{0} imágenes descargadas"
 
-#, java-format
 msgid "{0} image in total"
 msgid_plural "{0} images in total"
 msgstr[0] "{0} imágen en total"
 msgstr[1] "{0} imágenes en total"
 
-#, java-format
+msgid "{0} image submitted, Changeset key: {1}, State: {2}"
+msgid_plural "{0} images submitted, Changeset key: {1}, State: {2}"
+msgstr[0] "{0} imagen enviada, Clave de conjunto de cambios: {1}, Estado: {2}"
+msgstr[1] ""
+"{0} imágenes enviadas, Etiqueta de conjunto de cambios: {1}, Estado: {2}"
+
 msgid "{0} images in {1} sequences"
 msgstr "{0} imágenes en {1} secuencias"
 
-#, java-format
 msgid "{0} imported image"
 msgid_plural "{0} imported images"
 msgstr[0] "{0} imagen importada"
 msgstr[1] "{0} imágenes importadas"
 
-#, java-format
 msgid "{0} sequence, containing between {1} and {2} images (ø {3})"
 msgid_plural ""
 "{0} sequences, each containing between {1} and {2} images (ø {3})"
 msgstr[0] "{0} secuencia, contiene entre {1} y {2} imagenes (ø {3})"
 msgstr[1] "{0}secuencias, cada una contiene entre {1} y {2} imagenes (ø {3})"
 
-#. Plugin description for Mapillary
 msgid "Allows the user to work with pictures hosted at mapillary.com"
 msgstr "Permite al usuario trabajar con fotos hospedadas en mapillary.com"

--- a/src/main/po/fr.po
+++ b/src/main/po/fr.po
@@ -1,15 +1,15 @@
 # Translations for the JOSM plugin 'Mapillary' (fr)
-# Copyright (C) 2018 
+# Copyright (C) 2020
 # This file is distributed under the same license as the josm-plugin_Mapillary package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
-#, fuzzy
+#
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: josm-plugin_Mapillary v1.5.16-14-g82b2768\n"
+"Project-Id-Version: josm-plugin_Mapillary 1.5.20-3-ge40f8de\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-30 10:39+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"POT-Creation-Date: 2020-02-17 00:25+0000\n"
+"PO-Revision-Date: 2018-01-15 10:33+0000\n"
 "Language-Team: French (https://www.transifex.com/josm/teams/2544/fr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -23,7 +23,6 @@ msgstr "2 images assemblées"
 msgid "2 images unjoined"
 msgstr "2 images désassemblées"
 
-#, java-format
 msgid ""
 "A tag with key <i>{0}</i> is already present on the selected OSM object."
 msgstr ""
@@ -53,7 +52,6 @@ msgstr ""
 msgid "Cancel"
 msgstr "Annuler"
 
-#, java-format
 msgid "Changeset upload failed with {0} error ''{1} {2}''!"
 msgstr ""
 "Le téléversement du groupe de modification a échoué avec {0} erreurs \"{1} "
@@ -72,26 +70,21 @@ msgid "Could not import a geotagged image to the Mapillary layer!"
 msgstr ""
 "On ne peut pas importer une image géotagguée dans la couche Mapillary!"
 
-#, java-format
 msgid "Could not import the directory ''{0}''!"
 msgstr "Impossible d importer le répertoire \"{0}\"!"
 
-#, java-format
 msgid "Could not import the image ''{0}''!"
 msgstr "Impossible d’importer l’image ''{0}''!"
 
-#, java-format
 msgid "Could not open the URL {0} in a browser"
 msgstr "Impossible d ouvrir l URL {0} dans un navigateur"
 
-#, java-format
 msgid "Could not read from URL {0}!"
 msgstr "Impossible de lire depuis l URL {0}!"
 
 msgid "Current Mapillary changeset"
 msgstr "Groupe de modification Mapillary courant"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Cut off sequences at download bounds"
 msgstr "Couper les séquences aux limites de téléchargement"
 
@@ -101,13 +94,11 @@ msgstr "Jours"
 msgid "Delete after upload"
 msgstr "Effacer après l’envoi"
 
-#, java-format
 msgid "Deleted {0} image"
 msgid_plural "Deleted {0} images"
 msgstr[0] "{0} photo effacée"
 msgstr[1] "{0} photos effacées"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Display hour when the picture was taken"
 msgstr "Afficher l''heure de la prise de vue"
 
@@ -124,7 +115,6 @@ msgstr ""
 msgid "Displays the layer displaying the map objects detected by Mapillary"
 msgstr "Affiche le calque montrant les objets détectés par Mapillary"
 
-#, java-format
 msgid ""
 "Do you really want to replace the current value <i>{0}</i> with the new "
 "value <i>{1}</i>?"
@@ -153,7 +143,6 @@ msgstr "Téléchargement des objets de la carte…"
 msgid "Downloading…"
 msgstr "Téléchargement..."
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Enable experimental beta-features (might be unstable)"
 msgstr ""
 "Activer les beta-fonctionnalités expérimentales (peuvent être instables)"
@@ -173,6 +162,9 @@ msgstr "Exporter les images sélectionnées"
 msgid "Export selected sequence"
 msgstr "Exporter la séquence sélectionnée"
 
+msgid "Exporting Mapillary Images…"
+msgstr "Export des images Mapillary..."
+
 msgid "Finished upload"
 msgstr "Envoi terminé"
 
@@ -187,7 +179,6 @@ msgstr ""
 "De quelle source souhaitez-vous importer des images vers la couche "
 "Mapillary?"
 
-#. i18n: traffic sign
 msgid "Give way"
 msgstr "Cédez-le-passage"
 
@@ -235,13 +226,11 @@ msgstr "Importer des photos dans un calque Mapillary"
 msgid "Imported images"
 msgstr "Images importées"
 
-#, java-format
 msgid "Imported {0} image"
 msgid_plural "Imported {0} images"
 msgstr[0] "{0} image importée"
 msgstr[1] "{0} images importées"
 
-#. i18n: traffic sign
 msgid "Intersection danger"
 msgstr "Danger à l''intersection"
 
@@ -282,7 +271,6 @@ msgstr "Connexion réussie, retour à JOSM."
 msgid "Logout"
 msgstr "Déconnexion"
 
-#. i18n: traffic sign
 msgid "Mandatory direction (any)"
 msgstr "Prescription de sens (n''importe lequel)"
 
@@ -319,7 +307,6 @@ msgstr "Objets Mapillary"
 msgid "Months"
 msgstr "Mois"
 
-#, java-format
 msgid "Moved {0} image"
 msgid_plural "Moved {0} images"
 msgstr[0] "{0} image déplacée"
@@ -328,32 +315,27 @@ msgstr[1] "{0} images déplacées"
 msgid "Next picture"
 msgstr "Photo suivante"
 
-#. i18n: traffic sign
 msgid "No entry"
 msgstr "Aucune entrée"
-
-msgid "No image selected"
-msgstr "Pas d''image sélectionnée"
 
 msgid "No images found"
 msgstr "Aucune image trouvée"
 
-#. i18n: traffic sign
 msgid "No overtaking"
 msgstr "Interdiction de dépasser"
 
-#. i18n: traffic sign
 msgid "No parking"
 msgstr "Stationnement interdit"
 
-#. i18n: traffic sign
 msgid "No turn"
 msgstr "Changement de direction interdit"
+
+msgid "Not logged in to Mapillary"
+msgstr "Non connecté à Mapillary"
 
 msgid "Not older than: "
 msgstr "Pas plus vieux que : "
 
-#. i18n: Spinner label in JOSM settings
 msgid "Number of images to be pre-fetched (forwards and backwards)"
 msgstr "Nombre d images a pré-charger (vers l avant, vers l arrière)"
 
@@ -381,18 +363,15 @@ msgstr "Pause"
 msgid "Pauses the walk."
 msgstr "Suspend la marche."
 
-#. i18n: traffic sign
 msgid "Pedestrian crossing"
 msgstr "Passage piéton"
 
 msgid "Play"
 msgstr "Lecture"
 
-#, java-format
 msgid "Press \"{0}\" to download images"
 msgstr "Appuyez sur \"{0}\" pour télécharger des images"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Preview images when hovering its icon"
 msgstr "Aperçu des images lors du survol de l’icône"
 
@@ -408,7 +387,6 @@ msgstr "Rétablir"
 msgid "Rewrite imported images"
 msgstr "Réécrire les images importées"
 
-#. i18n: traffic sign
 msgid "Roundabout"
 msgstr "Giratoire"
 
@@ -436,7 +414,6 @@ msgstr "Voir la photo suivante"
 msgid "Shows the previous picture in the sequence"
 msgstr "Voir la photo précédente"
 
-#. i18n: traffic sign
 msgid "Speed limit"
 msgstr "Limite de vitesse"
 
@@ -444,7 +421,6 @@ msgctxt "as synonym to halt or stand still"
 msgid "Stop"
 msgstr "Stop"
 
-#. i18n: traffic sign
 msgctxt "name of the traffic sign"
 msgid "Stop"
 msgstr "Stop"
@@ -458,7 +434,6 @@ msgstr "Soumettez les changements"
 msgid "Submit the current changeset"
 msgstr "Soumettez l’ensemble des modifications actuelles"
 
-#. CHECKSTYLE.OFF: LineLength
 msgid "Submit the current changeset to Mapillary"
 msgstr "Soumettre le groupe de modification courant a Mapillary"
 
@@ -493,7 +468,6 @@ msgstr ""
 msgid "There are currently no layers with geotagged images!"
 msgstr "Il n''y a actuellement aucun calque avec des images géoréférencées!"
 
-#, java-format
 msgid ""
 "To solve this problem, you could switch to download mode ''{0}'' and load "
 "Mapillary images for a smaller portion of the map."
@@ -511,11 +485,9 @@ msgstr ""
 msgid "Too many map objects, zoom in to see all."
 msgstr "Tous les objets ne peuvent être affichés, zoomez pour voir tout."
 
-#, java-format
 msgid "Total Mapillary images: {0}"
 msgstr "Nombre total de photos : {0}"
 
-#, java-format
 msgid "Turned {0} image"
 msgid_plural "Turned {0} images"
 msgstr[0] "{0} image tournée"
@@ -524,7 +496,6 @@ msgstr[1] "{0} images tournées"
 msgid "Undo"
 msgstr "Annuler"
 
-#. i18n: traffic sign
 msgid "Uneven road"
 msgstr "Route déformée"
 
@@ -537,11 +508,9 @@ msgstr "Téléverser les images mapillary"
 msgid "Upload selected sequence"
 msgstr "Envoyer la séquence sélectionnée"
 
-#, java-format
 msgid "Uploading: {0}"
 msgstr "Envoi en cours : {0}"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Use 24 hour format"
 msgstr "Utiliser le système horaire sur 24 heures"
 
@@ -557,7 +526,6 @@ msgstr "Attendre les images en pleine résolution"
 msgid "Walk mode"
 msgstr "Mode piéton"
 
-#. i18n: Checkbox label in JOSM settings
 msgid ""
 "When opening Mapillary image in web browser, show the blur editor instead of"
 " the image viewer"
@@ -575,7 +543,6 @@ msgstr "Années"
 msgid "You are currently not logged in."
 msgstr "Vous n''êtes pas identifié."
 
-#, java-format
 msgid "You are logged in as ''{0}''."
 msgstr "Vous êtes connecté en tant que ''{0}''."
 
@@ -592,18 +559,18 @@ msgstr "Zoomer sur l’image Mapillary actuellement sélectionnée"
 msgid "approved"
 msgstr "approuvé"
 
-#. i18n: download mode for Mapillary images
 msgid "areas with downloaded OSM-data"
 msgstr "Zones avec données OSM téléchargées"
 
-#. i18n: download mode for Mapillary images
 msgid "everything in the visible area"
 msgstr "Tout est dans la zone visible"
 
 msgid "image has no key"
 msgstr "L,’image n’a pas de clé"
 
-#. i18n: download mode for Mapillary images
+msgid "no image selected"
+msgstr "aucune image sélectionnée"
+
 msgid "only when manually requested"
 msgstr "Uniquement lorsque demandé manuellement"
 
@@ -619,7 +586,6 @@ msgstr "La séquence n’a pas de clé"
 msgid "unknown user"
 msgstr "Utilisateur inconnu"
 
-#, java-format
 msgid ""
 "{0}\n"
 "Could not read map objects from URL\n"
@@ -629,14 +595,11 @@ msgstr ""
 "Impossible de lire les objets de la carte depuis l URL\n"
 "{1}!"
 
-#, java-format
 msgid "{0} detections"
 msgstr "{0} détections"
 
-#, java-format
 msgid "{0} images in {1} sequences"
 msgstr "{0} images dans {1} séquences"
 
-#. Plugin description for Mapillary
 msgid "Allows the user to work with pictures hosted at mapillary.com"
 msgstr "Donne accès aux photos hébergées sur mapillary.com"

--- a/src/main/po/hu.po
+++ b/src/main/po/hu.po
@@ -1,15 +1,15 @@
 # Translations for the JOSM plugin 'Mapillary' (hu)
-# Copyright (C) 2018 
+# Copyright (C) 2020
 # This file is distributed under the same license as the josm-plugin_Mapillary package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
-#, fuzzy
+#
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: josm-plugin_Mapillary v1.5.16-14-g82b2768\n"
+"Project-Id-Version: josm-plugin_Mapillary 1.5.20-3-ge40f8de\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-30 10:39+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"POT-Creation-Date: 2020-02-17 00:25+0000\n"
+"PO-Revision-Date: 2018-01-15 10:33+0000\n"
 "Language-Team: Hungarian (https://www.transifex.com/josm/teams/2544/hu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -18,12 +18,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgid "2 images joined"
-msgstr "2 két összekapcsolva"
+msgstr "2 kép egyesítve"
 
 msgid "2 images unjoined"
 msgstr "2 kép szétválasztva"
 
-#, java-format
 msgid ""
 "A tag with key <i>{0}</i> is already present on the selected OSM object."
 msgstr ""
@@ -52,7 +51,10 @@ msgstr ""
 msgid "Cancel"
 msgstr "Mégse"
 
-#, java-format
+msgid ""
+"Center view on new image when using the buttons to jump to another image"
+msgstr "Új képre való váltáskor az új kép középre igazítása"
+
 msgid "Changeset upload failed with {0} error ''{1} {2}''!"
 msgstr "A módosításcsomag feltöltése meghiúsult, hibakód: {0}, „{1} {2}”"
 
@@ -68,28 +70,26 @@ msgstr "Kulcs másolása"
 msgid "Could not import a geotagged image to the Mapillary layer!"
 msgstr "Nem sikerült a geokódolt kép importlása a Mapillary rétegre!"
 
-#, java-format
 msgid "Could not import the directory ''{0}''!"
 msgstr "A(z) „{0}” könyvtár nem importálható."
 
-#, java-format
 msgid "Could not import the image ''{0}''!"
 msgstr "A(z) „{0}” kép nem importálható."
 
-#, java-format
 msgid "Could not open the URL {0} in a browser"
 msgstr "A(z) {0} URL nem nyitható meg böngészőben"
 
-#, java-format
 msgid "Could not read from URL {0}!"
 msgstr "Nem sikerült olvasni a(z) {0} URL-ről!"
 
 msgid "Current Mapillary changeset"
 msgstr "Jelenlegi Mapillary módosításcsomag"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Cut off sequences at download bounds"
 msgstr "Sorozatok levágása a letöltési határokon"
+
+msgid "Dark mode for image display"
+msgstr "Kép kijelzésnél sötét mód"
 
 msgid "Days"
 msgstr "Nap"
@@ -97,13 +97,11 @@ msgstr "Nap"
 msgid "Delete after upload"
 msgstr "Feltöltés után törlés"
 
-#, java-format
 msgid "Deleted {0} image"
 msgid_plural "Deleted {0} images"
 msgstr[0] "{0} kép törölve"
 msgstr[1] "{0} kép törölve"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Display hour when the picture was taken"
 msgstr "Kép készítési idejének megjelenítése"
 
@@ -118,7 +116,6 @@ msgstr "Megjeleníti a Mapillary által az utcaképekről felismert objektumokat
 msgid "Displays the layer displaying the map objects detected by Mapillary"
 msgstr "Megjeleníti a Mapillary által észlelt térképobjektumokat"
 
-#, java-format
 msgid ""
 "Do you really want to replace the current value <i>{0}</i> with the new "
 "value <i>{1}</i>?"
@@ -146,7 +143,6 @@ msgstr "Összes térképobjektum letöltése…"
 msgid "Downloading…"
 msgstr "Letöltés…"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Enable experimental beta-features (might be unstable)"
 msgstr "Kísérleti béta funkciók engedélyezése (lehet hogy nem stabilak)"
 
@@ -180,7 +176,6 @@ msgstr "Létező képrétegről"
 msgid "From which source do you want to import images to the Mapillary layer?"
 msgstr "Melyik forrásból akarsz képeket importálni a Mapillary rétegre?"
 
-#. i18n: traffic sign
 msgid "Give way"
 msgstr "Elsőbbségadás kötelező"
 
@@ -228,13 +223,11 @@ msgstr "Képek importálása a Mapillary rétegre"
 msgid "Imported images"
 msgstr "Importált képek"
 
-#, java-format
 msgid "Imported {0} image"
 msgid_plural "Imported {0} images"
 msgstr[0] "{0} kép importálva"
 msgstr[1] "{0} kép importálva"
 
-#. i18n: traffic sign
 msgid "Intersection danger"
 msgstr "Veszélyes útkereszteződés"
 
@@ -275,7 +268,6 @@ msgstr "Bejelentkezés sikeres, vissza a JOSM-hez."
 msgid "Logout"
 msgstr "Kijelentkezés"
 
-#. i18n: traffic sign
 msgid "Mandatory direction (any)"
 msgstr "Kötelező haladási irány"
 
@@ -312,7 +304,6 @@ msgstr "Mapillary objektumok"
 msgid "Months"
 msgstr "Hónap"
 
-#, java-format
 msgid "Moved {0} image"
 msgid_plural "Moved {0} images"
 msgstr[0] "{0} kép áthelyezve"
@@ -321,32 +312,27 @@ msgstr[1] "{0} kép áthelyezve"
 msgid "Next picture"
 msgstr "Következő kép"
 
-#. i18n: traffic sign
 msgid "No entry"
 msgstr "Behajtani tilos"
-
-msgid "No image selected"
-msgstr "Nincs kép kijelölve"
 
 msgid "No images found"
 msgstr "Nem található kép"
 
-#. i18n: traffic sign
 msgid "No overtaking"
 msgstr "Előzni tilos"
 
-#. i18n: traffic sign
 msgid "No parking"
 msgstr "Várakozni tilos"
 
-#. i18n: traffic sign
 msgid "No turn"
 msgstr "Bekanyarodni tilos"
+
+msgid "Not logged in to Mapillary"
+msgstr "Nem vagy bejelentkezve Mapillary-be"
 
 msgid "Not older than: "
 msgstr "Nem régebbi mint: "
 
-#. i18n: Spinner label in JOSM settings
 msgid "Number of images to be pre-fetched (forwards and backwards)"
 msgstr "Előtöltendő képek száma (előre és hátra)"
 
@@ -374,18 +360,15 @@ msgstr "Szünet"
 msgid "Pauses the walk."
 msgstr "Szünetelteti a sétát."
 
-#. i18n: traffic sign
 msgid "Pedestrian crossing"
 msgstr "Gyalogosátkelő"
 
 msgid "Play"
 msgstr "Lejátszás"
 
-#, java-format
 msgid "Press \"{0}\" to download images"
 msgstr "Képek letöltéséhez nyomd meg a következőt: ''{0}''"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Preview images when hovering its icon"
 msgstr "Kép előnézete, ha az egér az ikon fölött áll"
 
@@ -401,7 +384,6 @@ msgstr "Alaphelyzet"
 msgid "Rewrite imported images"
 msgstr "Importált képek átírása"
 
-#. i18n: traffic sign
 msgid "Roundabout"
 msgstr "Körforgalom"
 
@@ -429,7 +411,6 @@ msgstr "Megmutatja a sorozat következő képét"
 msgid "Shows the previous picture in the sequence"
 msgstr "Megmutatja a sorozat előző képét"
 
-#. i18n: traffic sign
 msgid "Speed limit"
 msgstr "Sebességkorlátozás"
 
@@ -437,7 +418,6 @@ msgctxt "as synonym to halt or stand still"
 msgid "Stop"
 msgstr "Stoptábla"
 
-#. i18n: traffic sign
 msgctxt "name of the traffic sign"
 msgid "Stop"
 msgstr "Stoptábla"
@@ -451,7 +431,6 @@ msgstr "Módosításcsomag beküldése"
 msgid "Submit the current changeset"
 msgstr "Jelenlegi módosításcsomag beküldése"
 
-#. CHECKSTYLE.OFF: LineLength
 msgid "Submit the current changeset to Mapillary"
 msgstr "Jelenlegi módosításcsomag beküldése a Mapillary-re"
 
@@ -486,7 +465,6 @@ msgstr ""
 msgid "There are currently no layers with geotagged images!"
 msgstr "Jelenleg nincsenek geocímkézett képrétegek."
 
-#, java-format
 msgid ""
 "To solve this problem, you could switch to download mode ''{0}'' and load "
 "Mapillary images for a smaller portion of the map."
@@ -503,11 +481,9 @@ msgstr ""
 msgid "Too many map objects, zoom in to see all."
 msgstr "Túl sok térképobjektum, nagyíts hogy lásd mindet."
 
-#, java-format
 msgid "Total Mapillary images: {0}"
 msgstr "Összes Mapillary kép: {0}"
 
-#, java-format
 msgid "Turned {0} image"
 msgid_plural "Turned {0} images"
 msgstr[0] "{0} kép elfordítva"
@@ -516,7 +492,6 @@ msgstr[1] "{0} kép elfordítva"
 msgid "Undo"
 msgstr "Visszavonás"
 
-#. i18n: traffic sign
 msgid "Uneven road"
 msgstr "Egyenetlen úttest"
 
@@ -529,11 +504,9 @@ msgstr "Mapillary képek feltöltése"
 msgid "Upload selected sequence"
 msgstr "Kijelölt sorozat feltöltése"
 
-#, java-format
 msgid "Uploading: {0}"
 msgstr "Feltöltés: {0}"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Use 24 hour format"
 msgstr "24 órás formátum használata"
 
@@ -554,7 +527,6 @@ msgstr ""
 "Séta mód: A következő képre várakozás túl sokáig tart! Kilépés a séta "
 "módból…"
 
-#. i18n: Checkbox label in JOSM settings
 msgid ""
 "When opening Mapillary image in web browser, show the blur editor instead of"
 " the image viewer"
@@ -571,13 +543,24 @@ msgstr "Év"
 msgid "You are currently not logged in."
 msgstr "Jelenleg nem vagy bejelentkezve."
 
-#, java-format
 msgid "You are logged in as ''{0}''."
 msgstr "Be vagy jelentkezve „{0}” néven."
 
 msgid "You are not logged in, please log in to Mapillary in the preferences"
 msgstr ""
 "Nem vagy bejelentkezve. Kérlek jelentkezz be Mapillary-be a beállításokban"
+
+msgid ""
+"You are trying to upload a sequence to mapillary.com that you previously "
+"downloaded from there. That is not possible."
+msgstr ""
+"Olyan képeket próbálsz feltölteni a mapillary.com-ra, amiket korábban onnan "
+"töltöttél le. Ez nem lehetséges."
+
+msgid "You have successfully uploaded {0} image to mapillary.com"
+msgid_plural "You have successfully uploaded {0} images to mapillary.com"
+msgstr[0] "Sikeresen feltöltöttél {0} képet a mapillary.com-ra"
+msgstr[1] "Sikeresen feltöltöttél {0} képet a mapillary.com-ra"
 
 msgid "Zoom to selected image"
 msgstr "Nagyítás a kijelölt képre"
@@ -588,18 +571,18 @@ msgstr "Nagyítás a jelenleg kijelölt Mapillary képre"
 msgid "approved"
 msgstr "elfogadva"
 
-#. i18n: download mode for Mapillary images
 msgid "areas with downloaded OSM-data"
 msgstr "letöltött OSM-adatokat tartalmazó területek"
 
-#. i18n: download mode for Mapillary images
 msgid "everything in the visible area"
 msgstr "minden, a látható területen"
 
 msgid "image has no key"
 msgstr "a képnek nincs kulcsa"
 
-#. i18n: download mode for Mapillary images
+msgid "no image selected"
+msgstr "nincs kijelölt kép"
+
 msgid "only when manually requested"
 msgstr "csak kézi lekérésre"
 
@@ -615,7 +598,6 @@ msgstr "a sorozatnak nincs kulcsa"
 msgid "unknown user"
 msgstr "ismeretlen felhasználó"
 
-#, java-format
 msgid ""
 "{0}\n"
 "Could not read map objects from URL\n"
@@ -625,14 +607,42 @@ msgstr ""
 "A térképobjektumok nem olvashatóak az URL-ről\n"
 "{1}!"
 
-#, java-format
+msgid "{0} ({1} image)"
+msgid_plural "{0} ({1} images)"
+msgstr[0] "{0} ({1} kép)"
+msgstr[1] "{0} ({1} kép)"
+
 msgid "{0} detections"
 msgstr "{0} észlelés"
 
-#, java-format
+msgid "{0} downloaded image"
+msgid_plural "{0} downloaded images"
+msgstr[0] "{0} letöltött kép"
+msgstr[1] "{0} letöltött kép"
+
+msgid "{0} image in total"
+msgid_plural "{0} images in total"
+msgstr[0] "{0} kép összesen"
+msgstr[1] "{0} kép összesen"
+
+msgid "{0} image submitted, Changeset key: {1}, State: {2}"
+msgid_plural "{0} images submitted, Changeset key: {1}, State: {2}"
+msgstr[0] "{0} kép beküldve, Módosításcsomag kulcsa: {1}, Állapot: {2}"
+msgstr[1] "{0} kép beküldve, Módosításcsomag kulcsa: {1}, Állapot: {2}"
+
 msgid "{0} images in {1} sequences"
 msgstr "{0} kép {1} sorozatban"
 
-#. Plugin description for Mapillary
+msgid "{0} imported image"
+msgid_plural "{0} imported images"
+msgstr[0] "{0} importált kép"
+msgstr[1] "{0} importált kép"
+
+msgid "{0} sequence, containing between {1} and {2} images (ø {3})"
+msgid_plural ""
+"{0} sequences, each containing between {1} and {2} images (ø {3})"
+msgstr[0] "{0} sorozat, egyenként {1} és {2} közti képpel (ø {3})"
+msgstr[1] "{0} sorozat, egyenként {1} és {2} közti képpel (ø {3})"
+
 msgid "Allows the user to work with pictures hosted at mapillary.com"
 msgstr "Lehetővé teszi a mapillary.com fotóinak használatát"

--- a/src/main/po/it.po
+++ b/src/main/po/it.po
@@ -1,15 +1,15 @@
 # Translations for the JOSM plugin 'Mapillary' (it)
-# Copyright (C) 2018 
+# Copyright (C) 2020
 # This file is distributed under the same license as the josm-plugin_Mapillary package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
-#, fuzzy
+#
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: josm-plugin_Mapillary v1.5.16-14-g82b2768\n"
+"Project-Id-Version: josm-plugin_Mapillary 1.5.20-3-ge40f8de\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-30 10:39+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"POT-Creation-Date: 2020-02-17 00:25+0000\n"
+"PO-Revision-Date: 2018-01-15 10:33+0000\n"
 "Language-Team: Italian (https://www.transifex.com/josm/teams/2544/it/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -23,7 +23,6 @@ msgstr "2 imagini unite"
 msgid "2 images unjoined"
 msgstr "2 imagini separate"
 
-#, java-format
 msgid ""
 "A tag with key <i>{0}</i> is already present on the selected OSM object."
 msgstr ""
@@ -53,7 +52,12 @@ msgstr ""
 msgid "Cancel"
 msgstr "Annulla"
 
-#, java-format
+msgid ""
+"Center view on new image when using the buttons to jump to another image"
+msgstr ""
+"Posiziona sulla nuova immagine quando si utilizza i pulsanti di salto ad "
+"altra immagine"
+
 msgid "Changeset upload failed with {0} error ''{1} {2}''!"
 msgstr ""
 "Caricamento del gruppo di modifiche fallito con errore {0} ''{1} {2}''!"
@@ -71,28 +75,26 @@ msgid "Could not import a geotagged image to the Mapillary layer!"
 msgstr ""
 "Impossibile importare un’immagine geo-referenziata nel livello di Mapillary!"
 
-#, java-format
 msgid "Could not import the directory ''{0}''!"
 msgstr "Impossibile importare la directory ''{0}''!"
 
-#, java-format
 msgid "Could not import the image ''{0}''!"
 msgstr "Impossibile importare l’immagine ''{0}''!"
 
-#, java-format
 msgid "Could not open the URL {0} in a browser"
 msgstr "Impossibile aprire l’indirizzo {0} in un browser"
 
-#, java-format
 msgid "Could not read from URL {0}!"
 msgstr "Impossibile leggere dall’indirizzo {0}!"
 
 msgid "Current Mapillary changeset"
 msgstr "Gruppo di modifiche di Mapillary corrente"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Cut off sequences at download bounds"
 msgstr "Taglia le sequenze ai bordi della zona scaricata"
+
+msgid "Dark mode for image display"
+msgstr "Modalità scura per la visualizzazione delle immagini"
 
 msgid "Days"
 msgstr "Giorni"
@@ -100,13 +102,11 @@ msgstr "Giorni"
 msgid "Delete after upload"
 msgstr "Cancella dopo il caricamento"
 
-#, java-format
 msgid "Deleted {0} image"
 msgid_plural "Deleted {0} images"
 msgstr[0] "Immagine {0} cancellata"
 msgstr[1] "Immagini {0} cancellate"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Display hour when the picture was taken"
 msgstr "Mostra l''ora in cui è stata scattata la foto"
 
@@ -124,7 +124,6 @@ msgid "Displays the layer displaying the map objects detected by Mapillary"
 msgstr ""
 "Mostra il livello contenente gli oggetti della mappa rilevati da Mapillary"
 
-#, java-format
 msgid ""
 "Do you really want to replace the current value <i>{0}</i> with the new "
 "value <i>{1}</i>?"
@@ -153,7 +152,6 @@ msgstr "Scaricamento degli oggetti della mappa in corso…"
 msgid "Downloading…"
 msgstr "Download in corso…"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Enable experimental beta-features (might be unstable)"
 msgstr "Abilita funzioni beta sperimentali (potrebbe essere instabile)"
 
@@ -187,7 +185,6 @@ msgstr "Dal livello esistente delle immagini"
 msgid "From which source do you want to import images to the Mapillary layer?"
 msgstr "Da quale fonte vuoi importare immagini nel livello di Mapillary?"
 
-#. i18n: traffic sign
 msgid "Give way"
 msgstr "Dare la precedenza"
 
@@ -234,13 +231,11 @@ msgstr "Importa foto nel livello Mapillary"
 msgid "Imported images"
 msgstr "Immagini importate"
 
-#, java-format
 msgid "Imported {0} image"
 msgid_plural "Imported {0} images"
 msgstr[0] "Immagine {0} importata"
 msgstr[1] "Immagini {0} importate"
 
-#. i18n: traffic sign
 msgid "Intersection danger"
 msgstr "Pericolo di incrocio"
 
@@ -282,7 +277,6 @@ msgstr "Autenticazione riuscita, ritorno a JOSM."
 msgid "Logout"
 msgstr "Esci"
 
-#. i18n: traffic sign
 msgid "Mandatory direction (any)"
 msgstr "Direzione obbligatoria (qualsiasi)"
 
@@ -319,7 +313,6 @@ msgstr "oggetti di Mapillary"
 msgid "Months"
 msgstr "Mesi"
 
-#, java-format
 msgid "Moved {0} image"
 msgid_plural "Moved {0} images"
 msgstr[0] "Spostata {0} immagine"
@@ -328,25 +321,18 @@ msgstr[1] "Spostate {0} immagini"
 msgid "Next picture"
 msgstr "Immagine successiva"
 
-#. i18n: traffic sign
 msgid "No entry"
 msgstr "Divieto di accesso"
-
-msgid "No image selected"
-msgstr "Nessuna immagine selezionata"
 
 msgid "No images found"
 msgstr "Nessuna immagine trovata"
 
-#. i18n: traffic sign
 msgid "No overtaking"
 msgstr "Divieto di sorpasso"
 
-#. i18n: traffic sign
 msgid "No parking"
 msgstr "Divieto di parcheggio"
 
-#. i18n: traffic sign
 msgid "No turn"
 msgstr "Divieto di svolta"
 
@@ -356,7 +342,6 @@ msgstr "Non hai effettuato l’accesso a Mapillary"
 msgid "Not older than: "
 msgstr "Non più vecchio di: "
 
-#. i18n: Spinner label in JOSM settings
 msgid "Number of images to be pre-fetched (forwards and backwards)"
 msgstr "Numero di immagini da pre-caricare (in avanti e indietro)"
 
@@ -384,18 +369,15 @@ msgstr "Metti in pausa"
 msgid "Pauses the walk."
 msgstr "Sospende la camminata"
 
-#. i18n: traffic sign
 msgid "Pedestrian crossing"
 msgstr "Strisce pedonali"
 
 msgid "Play"
 msgstr "Riproduci"
 
-#, java-format
 msgid "Press \"{0}\" to download images"
 msgstr "Premi \"{0}\" per scaricare le immagini"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Preview images when hovering its icon"
 msgstr "Anteprima delle immagini quando il mouse passa sopra la loro icona"
 
@@ -411,7 +393,6 @@ msgstr "Azzera"
 msgid "Rewrite imported images"
 msgstr "Riscrivi le immagini importate"
 
-#. i18n: traffic sign
 msgid "Roundabout"
 msgstr "Rotatoria"
 
@@ -439,7 +420,6 @@ msgstr "Mostra la prossima immagine nella sequenza"
 msgid "Shows the previous picture in the sequence"
 msgstr "Mostra l’immagine precedente nella sequenza"
 
-#. i18n: traffic sign
 msgid "Speed limit"
 msgstr "Limite di velocità"
 
@@ -447,7 +427,6 @@ msgctxt "as synonym to halt or stand still"
 msgid "Stop"
 msgstr "Stop"
 
-#. i18n: traffic sign
 msgctxt "name of the traffic sign"
 msgid "Stop"
 msgstr "Stop"
@@ -461,7 +440,6 @@ msgstr "Invia il gruppo di modifiche"
 msgid "Submit the current changeset"
 msgstr "Invia il gruppo di modifiche attuale"
 
-#. CHECKSTYLE.OFF: LineLength
 msgid "Submit the current changeset to Mapillary"
 msgstr "Invia il gruppo di modifiche attuale a Mapillary"
 
@@ -497,7 +475,6 @@ msgstr ""
 msgid "There are currently no layers with geotagged images!"
 msgstr "Non ci sono livelli con immagini geo-referenziate in questo momento!"
 
-#, java-format
 msgid ""
 "To solve this problem, you could switch to download mode ''{0}'' and load "
 "Mapillary images for a smaller portion of the map."
@@ -514,11 +491,9 @@ msgstr ""
 msgid "Too many map objects, zoom in to see all."
 msgstr "Troppi oggetti della mappa, ingrandisci per vederli tutti."
 
-#, java-format
 msgid "Total Mapillary images: {0}"
 msgstr "Immagini Mapillary totali: {0}"
 
-#, java-format
 msgid "Turned {0} image"
 msgid_plural "Turned {0} images"
 msgstr[0] "Girato {0} immagine"
@@ -527,7 +502,6 @@ msgstr[1] "Girato {0} immagini"
 msgid "Undo"
 msgstr "Annulla"
 
-#. i18n: traffic sign
 msgid "Uneven road"
 msgstr "Strada sconnessa"
 
@@ -540,11 +514,9 @@ msgstr "Carica le immagini di Mapillary nel server"
 msgid "Upload selected sequence"
 msgstr "Carica nel server la sequenza selezionata"
 
-#, java-format
 msgid "Uploading: {0}"
 msgstr "In caricamento: {0}"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Use 24 hour format"
 msgstr "Utilizza il formato a 24 ore"
 
@@ -565,7 +537,6 @@ msgstr ""
 "Modalità camminata: il tempo necessario per l’immagine successiva è troppo "
 "lungo! Esco dalla modalità camminata…"
 
-#. i18n: Checkbox label in JOSM settings
 msgid ""
 "When opening Mapillary image in web browser, show the blur editor instead of"
 " the image viewer"
@@ -582,14 +553,19 @@ msgstr "Anni"
 msgid "You are currently not logged in."
 msgstr "Non sei autenticato."
 
-#, java-format
 msgid "You are logged in as ''{0}''."
 msgstr "Sei collegato come ''{0}''."
 
 msgid "You are not logged in, please log in to Mapillary in the preferences"
 msgstr "Non hai effettuato l’accesso, accedi a Mapillary nelle preferenze"
 
-#, java-format
+msgid ""
+"You are trying to upload a sequence to mapillary.com that you previously "
+"downloaded from there. That is not possible."
+msgstr ""
+"Si sta cercando di caricare una sequenza su mapillary.com che era stata "
+"precedentemente scaricata da lì. Ciò non è permesso."
+
 msgid "You have successfully uploaded {0} image to mapillary.com"
 msgid_plural "You have successfully uploaded {0} images to mapillary.com"
 msgstr[0] "Hai caricato con successo {0} immagine su mapillary.com"
@@ -604,18 +580,18 @@ msgstr "Ingrandisci sull’immagine di Mapillary attualmente selezionata"
 msgid "approved"
 msgstr "approvato"
 
-#. i18n: download mode for Mapillary images
 msgid "areas with downloaded OSM-data"
 msgstr "aree con dati OSM scaricati"
 
-#. i18n: download mode for Mapillary images
 msgid "everything in the visible area"
 msgstr "tutto nell’area visibile"
 
 msgid "image has no key"
 msgstr "l’immagine non ha una chiave"
 
-#. i18n: download mode for Mapillary images
+msgid "no image selected"
+msgstr "nessuna immagine selezionata"
+
 msgid "only when manually requested"
 msgstr "solo quando richiesto manualmente"
 
@@ -631,7 +607,6 @@ msgstr "la sequenza non ha una chiave"
 msgid "unknown user"
 msgstr "utente sconosciuto"
 
-#, java-format
 msgid ""
 "{0}\n"
 "Could not read map objects from URL\n"
@@ -641,30 +616,24 @@ msgstr ""
 "Impossibile leggere oggetti della mappa dall’indirizzo\n"
 "{1}!"
 
-#. i18n: {0} is the layer name, {1} the number of images in it
-#, java-format
 msgid "{0} ({1} image)"
 msgid_plural "{0} ({1} images)"
 msgstr[0] "{0} ({1} immagine)"
 msgstr[1] "{0} ({1} immagini)"
 
-#, java-format
 msgid "{0} detections"
 msgstr "{0} rilevamenti"
 
-#, java-format
 msgid "{0} downloaded image"
 msgid_plural "{0} downloaded images"
 msgstr[0] "{0} immagine scaricata"
 msgstr[1] "{0} immagini scaricate"
 
-#, java-format
 msgid "{0} image in total"
 msgid_plural "{0} images in total"
 msgstr[0] "{0} immagine in totale"
 msgstr[1] "{0} immagini in totale"
 
-#, java-format
 msgid "{0} image submitted, Changeset key: {1}, State: {2}"
 msgid_plural "{0} images submitted, Changeset key: {1}, State: {2}"
 msgstr[0] ""
@@ -672,17 +641,14 @@ msgstr[0] ""
 msgstr[1] ""
 "{0} immagini inviate, Chiave del gruppo di modifiche: {1}, Stato: {2}"
 
-#, java-format
 msgid "{0} images in {1} sequences"
 msgstr "{0} immagini in {1} sequenze"
 
-#, java-format
 msgid "{0} imported image"
 msgid_plural "{0} imported images"
 msgstr[0] "{0} immagine importata"
 msgstr[1] "{0} immagini importate"
 
-#, java-format
 msgid "{0} sequence, containing between {1} and {2} images (ø {3})"
 msgid_plural ""
 "{0} sequences, each containing between {1} and {2} images (ø {3})"
@@ -691,7 +657,6 @@ msgstr[0] ""
 msgstr[1] ""
 "{0} sequenze, ognuna contenente tra le {1} e le {2} immagini (ø {3})"
 
-#. Plugin description for Mapillary
 msgid "Allows the user to work with pictures hosted at mapillary.com"
 msgstr ""
 "Permette all’utente di lavorare con immagini ospitate su mapillary.com"

--- a/src/main/po/ja.po
+++ b/src/main/po/ja.po
@@ -1,22 +1,15 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2019 THE PACKAGE'S COPYRIGHT HOLDER
+# Translations for the JOSM plugin 'Mapillary' (ja)
+# Copyright (C) 2020
 # This file is distributed under the same license as the josm-plugin_Mapillary package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
-# Translators:
-# Florian Schäfer, 2018
-# Simon Legner <simon.legner@gmail.com>, 2018
-# Hiroshi Miura <miurahr@northside.tokyo>, 2019
-# jun meguro <jmaguro@gmail.com>, 2019
-# 
-#, fuzzy
+#
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: josm-plugin_Mapillary 1.5.18-1-gf52835b\n"
+"Project-Id-Version: josm-plugin_Mapillary 1.5.20-3-ge40f8de\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-05 19:52+0000\n"
+"POT-Creation-Date: 2020-02-17 00:25+0000\n"
 "PO-Revision-Date: 2018-01-15 10:33+0000\n"
-"Last-Translator: jun meguro <jmaguro@gmail.com>, 2019\n"
 "Language-Team: Japanese (https://www.transifex.com/josm/teams/2544/ja/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -24,33 +17,25 @@ msgstr ""
 "Language: ja\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/history/commands/CommandJoin.java#L61
 msgid "2 images joined"
 msgstr "2つの画像を結合しました。"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/history/commands/CommandUnjoin.java#L61
 msgid "2 images unjoined"
 msgstr "2つの画像を分離しました。"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageinfo/AddTagToPrimitiveAction.java#L48
-#, java-format
 msgid ""
 "A tag with key <i>{0}</i> is already present on the selected OSM object."
 msgstr "キー<i>{0}</i>が付いたタグが、選択したOSMオブジェクトにすでに存在しています。"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageinfo/ImageInfoPanel.java#L98
 msgid "Add Mapillary tag"
 msgstr "Mapillary タグを追加"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/dialog/ImportMethodDialog.java#L43
 msgid "All images in a directory"
 msgstr "ディレクトリ中の全画像"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/layer/MapObjectLayer.java#L37
 msgid "All map objects loaded."
 msgstr "読みこんだ全マップオブジェクト"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/actions/MapillarySubmitCurrentChangesetAction.java#L113
 msgid ""
 "An exception occured while trying to submit a changeset. If this happens "
 "repeatedly, consider reporting a bug via the Help menu. If this message "
@@ -59,567 +44,399 @@ msgid ""
 msgstr ""
 "変更セットを送信時に例外が発生しました。繰り返し発生する場合は、ヘルプメニューからバグ報告することを検討ください。このメッセージを初めて見た場合は、再実施してみてください。インターネット接続に問題があるようです。"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/dialog/ChooseGeoImageLayersDialog.java#L59
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/dialog/ImportMethodDialog.java#L46
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/actions/MapillaryExportAction.java#L61
 msgid "Cancel"
 msgstr "キャンセル"
 
-#. i18n: Checkbox label in JOSM settings
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryPreferenceSetting.java#L67
 msgid ""
 "Center view on new image when using the buttons to jump to another image"
 msgstr "他の画像へボタンでジャンプしたときに、新しい画像は中央表示する。"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/actions/MapillarySubmitCurrentChangesetAction.java#L100
-#, java-format
 msgid "Changeset upload failed with {0} error ''{1} {2}''!"
 msgstr "変更セットのアップロードに、{0} エラー \"{1} {2}\"で失敗しました!"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryFilterDialog.java#L326
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryFilterDialog.java#L336
 msgid "Choose signs"
 msgstr "標識を選択"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryMainDialog.java#L385
 msgid "Continues with the paused walk."
 msgstr "開始"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageinfo/ImageInfoPanel.java#L94
 msgid "Copy key"
 msgstr "キーをコピー"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/dialog/ChooseGeoImageLayersDialog.java#L79
 msgid "Could not import a geotagged image to the Mapillary layer!"
 msgstr "Mapillaryレイヤに、ジオタグされた画像のインポートができませんでした!"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/dialog/ImportMethodDialog.java#L128
-#, java-format
 msgid "Could not import the directory ''{0}''!"
 msgstr "ディレクトリ \"{0}\"をインポートできませんでした!"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/dialog/ImportMethodDialog.java#L107
-#, java-format
 msgid "Could not import the image ''{0}''!"
 msgstr "画像\"{0}\"をインポートできませんでした!"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageinfo/WebLinkAction.java#L44
-#, java-format
 msgid "Could not open the URL {0} in a browser"
 msgstr "URL {0} をブラウザで開けませんでした。"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/io/download/BoundsDownloadRunnable.java#L42
-#, java-format
 msgid "Could not read from URL {0}!"
 msgstr "URL {0}をよみこめません!"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryChangesetDialog.java#L66
 msgid "Current Mapillary changeset"
 msgstr "現在のMapillary変更セット"
 
-#. i18n: Checkbox label in JOSM settings
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryPreferenceSetting.java#L76
 msgid "Cut off sequences at download bounds"
 msgstr "ダウンロードした境界でシーケンスを分断する"
 
-#. i18n: Checkbox label in JOSM settings
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryPreferenceSetting.java#L73
 msgid "Dark mode for image display"
 msgstr "画像ウインドウでダークモードを使用する"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryFilterDialog.java#L52
 msgid "Days"
 msgstr "日"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryUploadDialog.java#L48
 msgid "Delete after upload"
 msgstr "アップロード後削除"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/history/commands/CommandDelete.java#L48
-#, java-format
 msgid "Deleted {0} image"
 msgid_plural "Deleted {0} images"
 msgstr[0] "{0} この画像を削除"
 
-#. i18n: Checkbox label in JOSM settings
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryPreferenceSetting.java#L61
 msgid "Display hour when the picture was taken"
 msgstr "写真のとられた時刻を表示"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageinfo/ImageInfoPanel.java#L60
 msgid "Displays detail information on the currently selected Mapillary image"
 msgstr "現在選択されているMapillary画像の詳細情報を表示"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/layer/MapObjectLayer.java#L183
 msgid "Displays objects detected by Mapillary from their street view imagery"
 msgstr "ストリートビュー画像からMapillaryが検出したオブジェクトを表示"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/actions/MapObjectLayerAction.java#L21
 msgid "Displays the layer displaying the map objects detected by Mapillary"
 msgstr "Mapillaryが検出したマップオブジェクトのレイヤーを表示"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageinfo/AddTagToPrimitiveAction.java#L50
-#, java-format
 msgid ""
 "Do you really want to replace the current value <i>{0}</i> with the new "
 "value <i>{1}</i>?"
 msgstr "本当に現在の値 <i>{0}</i>を新しい<i>{1}</i>に変更しますか？"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/actions/MapillaryDownloadViewAction.java#L28
 msgid "Download Mapillary images in current view"
 msgstr "現在のビューにMapillary画像をダウンロード"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryPreferenceSetting.java#L135
 msgid "Download mode"
 msgstr "ダウンロードモード"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryFilterDialog.java#L264
 msgid "Downloaded images"
 msgstr "ダウンロードした画像"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryUtils.java#L269
 msgid "Downloading Mapillary images"
 msgstr "Mapillary画像をダウンロード中"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/layer/MapObjectLayer.java#L39
 msgid "Downloading map objects failed!"
 msgstr "マップオブジェクトのダウンロードに失敗!"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/layer/MapObjectLayer.java#L36
 msgid "Downloading map objects…"
 msgstr "マップオブジェクトのダウンロード中..."
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/io/export/MapillaryExportManager.java#L54
 msgid "Downloading…"
 msgstr "ダウンロード中..."
 
-#. i18n: Checkbox label in JOSM settings
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryPreferenceSetting.java#L85
 msgid "Enable experimental beta-features (might be unstable)"
 msgstr "実験的ベータ機能を有効化(不安定です)"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryExportDialog.java#L87
 msgid "Explore"
 msgstr "参照"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/actions/MapillaryExportAction.java#L48
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/actions/MapillaryExportAction.java#L49
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/actions/MapillaryExportAction.java#L50
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/actions/MapillaryExportAction.java#L68
 msgid "Export Mapillary images"
 msgstr "Mapillary画像をエクスポート"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryExportDialog.java#L68
 msgid "Export all images"
 msgstr "すべての画像をエクスポート"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryExportDialog.java#L72
 msgid "Export selected images"
 msgstr "選択した画像をエクスポート"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryExportDialog.java#L70
 msgid "Export selected sequence"
 msgstr "選択したシーケンスをエクスポート"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/io/export/MapillaryExportManager.java#L55
 msgid "Exporting Mapillary Images…"
 msgstr "Mapillary画像のエクスポート中..."
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/PluginState.java#L111
 msgid "Finished upload"
 msgstr "アップロード完了"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryWalkDialog.java#L46
 msgid "Follow selected image"
 msgstr "選択した画像をフォロー"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/dialog/ImportMethodDialog.java#L45
 msgid "From existing image layer"
 msgstr "画像レイヤーから出る"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/dialog/ImportMethodDialog.java#L39
 msgid "From which source do you want to import images to the Mapillary layer?"
 msgstr "どの情報源からMapillaryレイヤへ画像をインポートしますか？"
 
-#. i18n: traffic sign
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryFilterChooseSigns.java#L69
 msgid "Give way"
 msgstr "徐行"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryWalkDialog.java#L50
 msgid "Go forward"
 msgstr "次にすすむ"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryUploadDialog.java#L38
 msgid "Go to setting and log in to Mapillary before uploading."
 msgstr "アップロードの前に、設定に行ってMapillaryにログインしてください。"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageinfo/ImageInfoHelpPopup.java#L65
 msgid "I got it, close this."
 msgstr "クローズしました。"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageinfo/ImageInfoPanel.java#L123
 msgid "Image actions"
 msgstr "画像の操作"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageinfo/ImageInfoPanel.java#L118
 msgid "Image detections"
 msgstr "画像検出物"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageinfo/ImageInfoPanel.java#L58
 msgid "Image info"
 msgstr "画像情報"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageinfo/ImageInfoPanel.java#L125
 msgid "Image key"
 msgstr "画像キー"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/dialog/ImportMethodDialog.java#L41
 msgid "Images from my file system"
 msgstr "ファイルシステムからの画像"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/dialog/ChooseGeoImageLayersDialog.java#L63
 msgid "Import"
 msgstr "インポート"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/dialog/ImportMethodDialog.java#L107
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/dialog/ImportMethodDialog.java#L128
 msgid "Import exception"
 msgstr "インポート例外発生"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/actions/MapillaryImportAction.java#L36
 msgid "Import local pictures"
 msgstr "ローカルの写真をインポート"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/actions/MapillaryImportAction.java#L34
 msgid "Import pictures"
 msgstr "写真をインポート"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/actions/MapillaryImportAction.java#L37
 msgid "Import pictures into Mapillary layer"
 msgstr "写真をMapillaryレイヤにインポート"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryFilterDialog.java#L66
 msgid "Imported images"
 msgstr "インポートした画像"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/history/commands/CommandImport.java#L54
-#, java-format
 msgid "Imported {0} image"
 msgid_plural "Imported {0} images"
 msgstr[0] "インポートした {0}この画像"
 
-#. i18n: traffic sign
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryFilterChooseSigns.java#L75
 msgid "Intersection danger"
 msgstr "危険交差点"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageinfo/ImageInfoHelpPopup.java#L48
 msgid ""
 "It can be activated by clicking the left button at the bottom of this "
 "message or the button in the toolbar on the left, which uses the same icon."
 msgstr "このメッセージの下、または左側のツールバー内に同じアイコンで表示されたボタンを左クリックすることで有効化されます。"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/mode/JoinMode.java#L91
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/actions/MapillaryJoinAction.java#L30
 msgid "Join mode"
 msgstr "結合モード"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/actions/MapillaryJoinAction.java#L31
 msgid "Join/unjoin pictures"
 msgstr "画像の結合/分離"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/actions/SelectNextImageAction.java#L59
 msgid "Jump to blue"
 msgstr "青へとぶ"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/actions/SelectNextImageAction.java#L52
 msgid "Jump to red"
 msgstr "赤へとぶ"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/actions/SelectNextImageAction.java#L60
 msgid "Jumps to the picture at the other side of the blue line"
 msgstr "青い線のむこう側の写真にジャンプします"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/actions/SelectNextImageAction.java#L53
 msgid "Jumps to the picture at the other side of the red line"
 msgstr "赤い線のむこう側の写真にジャンプします"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageinfo/ClipboardAction.java#L51
 msgid "Key copied to clipboard…"
 msgstr "キーをクリップボードにコピー..."
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryPreferenceSetting.java#L232
 msgid "Login"
 msgstr "ログイン"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/oauth/OAuthPortListener.java#L32
 msgid "Login successful, return to JOSM."
 msgstr "ログインに成功しました。JOSMにもどります。"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryPreferenceSetting.java#L258
 msgid "Logout"
 msgstr "ログアウト"
 
-#. i18n: traffic sign
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryFilterChooseSigns.java#L77
 msgid "Mandatory direction (any)"
 msgstr "一方通行(各種)"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/actions/MapillaryDownloadAction.java#L36
 msgid "Mapillary"
 msgstr "Mapillary"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/MapillaryLayer.java#L106
 msgid "Mapillary Images"
 msgstr "Mapillary 画像"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryChangesetDialog.java#L70
 msgid "Mapillary changeset"
 msgstr "Mapillaryの変更セット"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryFilterDialog.java#L75
 msgid "Mapillary filter"
 msgstr "Mapillaryフィルタ"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryHistoryDialog.java#L73
 msgid "Mapillary history"
 msgstr "Mapillaryヒストリ"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryMainDialog.java#L54
 msgid "Mapillary image"
 msgstr "Mapillary画像"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/MapillaryLayer.java#L441
 msgid "Mapillary layer"
 msgstr "Mapillary レイヤ"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/oauth/OAuthPortListener.java#L31
 msgid "Mapillary login"
 msgstr "Mapillaryログイン"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/actions/MapObjectLayerAction.java#L19
 msgid "Mapillary object layer"
 msgstr "Mapillaryオブジェクトレイヤ"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/layer/MapObjectLayer.java#L69
 msgid "Mapillary objects"
 msgstr "Mapillaryオブジェクト"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryFilterDialog.java#L52
 msgid "Months"
 msgstr "ヶ月"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/history/commands/CommandMove.java#L58
-#, java-format
 msgid "Moved {0} image"
 msgid_plural "Moved {0} images"
 msgstr[0] "{0}この画像を移動"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/actions/SelectNextImageAction.java#L20
 msgid "Next picture"
 msgstr "次の画像"
 
-#. i18n: traffic sign
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryFilterChooseSigns.java#L73
 msgid "No entry"
 msgstr "エントリー無し"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryUtils.java#L275
 msgid "No images found"
 msgstr "画像がみつかりません"
 
-#. i18n: traffic sign
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryFilterChooseSigns.java#L83
 msgid "No overtaking"
 msgstr "追い越し禁止"
 
-#. i18n: traffic sign
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryFilterChooseSigns.java#L81
 msgid "No parking"
 msgstr "駐車禁止"
 
-#. i18n: traffic sign
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryFilterChooseSigns.java#L87
 msgid "No turn"
 msgstr "転回禁止"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/PluginState.java#L122
 msgid "Not logged in to Mapillary"
 msgstr "Mapillaryにログインしていません"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryFilterDialog.java#L85
 msgid "Not older than: "
 msgstr "アップロード期間"
 
-#. i18n: Spinner label in JOSM settings
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryPreferenceSetting.java#L149
 msgid "Number of images to be pre-fetched (forwards and backwards)"
 msgstr "先行して取得する画像数(前向きと後ろ向き)"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryFilterDialog.java#L307
 msgid "Only images with signs"
 msgstr "標識のある画像のみ"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryChangesetDialog.java#L68
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryChangesetDialog.java#L70
 msgid "Open Mapillary changeset dialog"
 msgstr "Mapillary変更セットダイアログを開く"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryFilterDialog.java#L75
 msgid "Open Mapillary filter dialog"
 msgstr "Mapillaryフィルタダイアログを開く"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryHistoryDialog.java#L73
 msgid "Open Mapillary history dialog"
 msgstr "Mapillaryヒストリダイアログを開く"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/actions/MapillaryDownloadAction.java#L29
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/actions/MapillaryDownloadAction.java#L38
 msgid "Open Mapillary layer"
 msgstr "Mapillaryレイヤを開く"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryMainDialog.java#L103
 msgid "Open Mapillary window"
 msgstr "Mapillaryウインドウを開く"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryMainDialog.java#L413
 msgid "Pause"
 msgstr "一時停止"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryMainDialog.java#L414
 msgid "Pauses the walk."
 msgstr "自動再生を一時停止"
 
-#. i18n: traffic sign
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryFilterChooseSigns.java#L85
 msgid "Pedestrian crossing"
 msgstr "横断歩道"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryMainDialog.java#L384
 msgid "Play"
 msgstr "再生"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryImageDisplay.java#L497
-#, java-format
 msgid "Press \"{0}\" to download images"
 msgstr "画像をダウンロードするには\"{0}\"を押下"
 
-#. i18n: Checkbox label in JOSM settings
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryPreferenceSetting.java#L70
 msgid "Preview images when hovering its icon"
 msgstr "アイコンの上に移動したとき画像をプレビュー"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/actions/SelectNextImageAction.java#L36
 msgid "Previous picture"
 msgstr "前の画像"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryHistoryDialog.java#L221
 msgid "Redo"
 msgstr "やり直し"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryFilterDialog.java#L292
 msgid "Reset"
 msgstr "リセット"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryExportDialog.java#L74
 msgid "Rewrite imported images"
 msgstr "インポートした画像を再書き込み"
 
-#. i18n: traffic sign
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryFilterChooseSigns.java#L71
 msgid "Roundabout"
 msgstr "環状交差点"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryExportDialog.java#L86
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryExportDialog.java#L114
 msgid "Select a directory"
 msgstr "ディレクトリを選択"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/dialog/ImportMethodDialog.java#L44
 msgid "Select directory to import images from"
 msgstr "画像をインポートするディレクトリを選択"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/mode/SelectMode.java#L185
 msgid "Select mode"
 msgstr "選択モード"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/dialog/ImportMethodDialog.java#L42
 msgid "Select the images you want to import"
 msgstr "インポートしたい画像を選択"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageinfo/ImageInfoPanel.java#L127
 msgid "Sequence key"
 msgstr "シーケンスキー"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageinfo/ImageInfoPanel.java#L78
 msgid "Show detections on top of image"
 msgstr "イメージ上に検出物を表示"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/actions/SelectNextImageAction.java#L21
 msgid "Shows the next picture in the sequence"
 msgstr "シーケンスの次の写真を表示"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/actions/SelectNextImageAction.java#L37
 msgid "Shows the previous picture in the sequence"
 msgstr "シーケンスの前の写真を表示"
 
-#. i18n: traffic sign
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryFilterChooseSigns.java#L65
 msgid "Speed limit"
 msgstr "最高速度"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryMainDialog.java#L357
 msgctxt "as synonym to halt or stand still"
 msgid "Stop"
 msgstr "停止"
 
-#. i18n: traffic sign
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryFilterChooseSigns.java#L67
 msgctxt "name of the traffic sign"
 msgid "Stop"
 msgstr "停止"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryMainDialog.java#L358
 msgid "Stops the walk."
 msgstr "自動再生を停止。"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/actions/MapillarySubmitCurrentChangesetAction.java#L48
 msgid "Submit changeset"
 msgstr "変更セット送信"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/actions/MapillarySubmitCurrentChangesetAction.java#L50
 msgid "Submit the current changeset"
 msgstr "現在の変更セットの送信"
 
-#. CHECKSTYLE.OFF: LineLength
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/actions/MapillarySubmitCurrentChangesetAction.java#L52
 msgid "Submit the current changeset to Mapillary"
 msgstr "Mapillaryへ現在の変更セットを送信する"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryUtils.java#L273
 msgid "Submitting Mapillary Changeset"
 msgstr "Mapillary変更セット送信"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryChangesetDialog.java#L91
 msgid "Submitting changeset to server…"
 msgstr "変更セットをサーバへ送信中..."
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/ImageImportUtil.java#L165
 msgid "Supported image formats (JPG and PNG)"
 msgstr "サポートされる画像フォーマット(JPGとPNG)"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageinfo/AddTagToPrimitiveAction.java#L54
 msgid "Tag conflict"
 msgstr "タグの衝突"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/io/download/MapillaryDownloader.java#L205
 msgid ""
 "The Mapillary layer has stopped downloading images, because the requested "
 "area is too big!"
 msgstr "要求された領域が広すぎるため、Mapillaryレイヤは画像ダウンロードを停止しました。"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageinfo/ImageInfoHelpPopup.java#L46
 msgid ""
 "The Mapillary plugin now uses a separate panel to display extra information "
 "(like the image key) and actions for the currently selected Mapillary image "
@@ -627,184 +444,129 @@ msgid ""
 msgstr ""
 "Mapillaryプラグインは現在、(画像キー等の)追加情報を表示するパネルや、現在選択されているMapillary画像への(ブラウザ上への表示等の)処理のパネルが分割されています。"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/dialog/ImportMethodDialog.java#L40
 msgid "There are currently no layers with geotagged images!"
 msgstr "ジオタグされた画像があるレイヤーは、現在ありません。"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/io/download/MapillaryDownloader.java#L208
-#, java-format
 msgid ""
 "To solve this problem, you could switch to download mode ''{0}'' and load "
 "Mapillary images for a smaller portion of the map."
 msgstr "この問題を解決するには、ダウンロードモード\"{0}\"に切りかえ、地図の小さな領域でMapillary画像を読みこんでみてください。"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/io/download/MapillaryDownloader.java#L207
 msgid ""
 "To solve this problem, you could zoom in and load a smaller area of the map."
 msgstr "この問題を解決するには、ズームインして地図上のより小さな領域を読みこんでみてください。"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/layer/MapObjectLayer.java#L38
 msgid "Too many map objects, zoom in to see all."
 msgstr "マップオブジェクトが多すぎます。全てをみるにはズームインしてください。"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryUtils.java#L271
-#, java-format
 msgid "Total Mapillary images: {0}"
 msgstr "総Mapillaryイメージ数: {0}"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/history/commands/CommandTurn.java#L53
-#, java-format
 msgid "Turned {0} image"
 msgid_plural "Turned {0} images"
 msgstr[0] "{0} 個の画像を回転しました。"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryHistoryDialog.java#L206
 msgid "Undo"
 msgstr "元に戻す"
 
-#. i18n: traffic sign
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryFilterChooseSigns.java#L79
 msgid "Uneven road"
 msgstr "未舗装道路"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryFilterDialog.java#L278
 msgid "Update"
 msgstr "アップデート"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/actions/MapillaryUploadAction.java#L32
 msgid "Upload Mapillary images"
 msgstr "Mapillary画像のアップロード"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryUploadDialog.java#L41
 msgid "Upload selected sequence"
 msgstr "選択したシーケンスのアップロード"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/PluginState.java#L136
-#, java-format
 msgid "Uploading: {0}"
 msgstr "アップロード中: {0}"
 
-#. i18n: Checkbox label in JOSM settings
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryPreferenceSetting.java#L64
 msgid "Use 24 hour format"
 msgstr "24時間表記を使用"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryFilterDialog.java#L104
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageinfo/ImageInfoPanel.java#L121
 msgid "User"
 msgstr "ユーザー"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageinfo/ImageInfoPanel.java#L92
 msgid "View in browser"
 msgstr "ブラウザで表示"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryWalkDialog.java#L42
 msgid "Wait for full quality pictures"
 msgstr "フル品質の写真を待つ"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/actions/MapillaryWalkAction.java#L39
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/actions/MapillaryWalkAction.java#L40
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/actions/MapillaryWalkAction.java#L49
 msgid "Walk mode"
 msgstr "自動再生モード"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/actions/WalkThread.java#L75
 msgid "Walk mode: Waiting for next image takes too long! Exiting walk mode…"
 msgstr "自動再生モード： 次画像の表示に時間が掛りすぎます。自動再生モードの中止..."
 
-#. i18n: Checkbox label in JOSM settings
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryPreferenceSetting.java#L80
 msgid ""
 "When opening Mapillary image in web browser, show the blur editor instead of"
 " the image viewer"
 msgstr "Mapillary画像をWebブラウザで開くときに、画像ビューアの代わりにブラー編集画面を開きます。"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/dialog/ChooseGeoImageLayersDialog.java#L41
 msgid "Which image layers do you want to import into the Mapillary layer?"
 msgstr "どの画像レイヤをMapillaryレイヤにインポートしますか？"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryFilterDialog.java#L52
 msgid "Years"
 msgstr "年"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryPreferenceSetting.java#L193
 msgid "You are currently not logged in."
 msgstr "ログインしていません"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryPreferenceSetting.java#L184
-#, java-format
 msgid "You are logged in as ''{0}''."
 msgstr "''{0}'' としてログイン中です。"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/PluginState.java#L121
 msgid "You are not logged in, please log in to Mapillary in the preferences"
 msgstr "まだログインしていません。Mapillaryに設定からログインしてください。"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/oauth/UploadUtils.java#L103
 msgid ""
 "You are trying to upload a sequence to mapillary.com that you previously "
 "downloaded from there. That is not possible."
 msgstr "以前ダウンロードしたシーケンスをMapillary.comへアップロードしようとしています。その処理はできません。"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/PluginState.java#L110
-#, java-format
 msgid "You have successfully uploaded {0} image to mapillary.com"
 msgid_plural "You have successfully uploaded {0} images to mapillary.com"
 msgstr[0] "{0}この画像をmapillary.comへアップロード完了しました。"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/actions/MapillaryZoomAction.java#L33
 msgid "Zoom to selected image"
 msgstr "選択した画像へズーム"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/actions/MapillaryZoomAction.java#L35
 msgid "Zoom to the currently selected Mapillary image"
 msgstr "現在選択しているMapillary画像へズームします。"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/actions/MapillarySubmitCurrentChangesetAction.java#L86
 msgid "approved"
 msgstr "承認済み"
 
-#. i18n: download mode for Mapillary images
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/io/download/MapillaryDownloader.java#L32
 msgid "areas with downloaded OSM-data"
 msgstr "OSMデータをダウンロードした領域"
 
-#. i18n: download mode for Mapillary images
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/io/download/MapillaryDownloader.java#L30
 msgid "everything in the visible area"
 msgstr "みえている領域全部"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageinfo/ImageInfoPanel.java#L218
 msgid "image has no key"
 msgstr "画像にはキーがない"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryImageDisplay.java#L497
 msgid "no image selected"
 msgstr "画像が選択されていない"
 
-#. i18n: download mode for Mapillary images
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/io/download/MapillaryDownloader.java#L34
 msgid "only when manually requested"
 msgstr "手動で要求されたときのみ"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/actions/MapillarySubmitCurrentChangesetAction.java#L85
 msgid "pending"
 msgstr "保留"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/actions/MapillarySubmitCurrentChangesetAction.java#L84
 msgid "rejected"
 msgstr "却下"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageinfo/ImageInfoPanel.java#L238
 msgid "sequence has no key"
 msgstr "シーケンスにキーがない"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageinfo/ImageInfoPanel.java#L229
 msgid "unknown user"
 msgstr "ユーザ不明"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/io/download/MapObjectDownloadRunnable.java#L70
-#, java-format
 msgid ""
 "{0}\n"
 "Could not read map objects from URL\n"
@@ -814,54 +576,36 @@ msgstr ""
 "URL {1}\n"
 "からマップオブジェクトを読みこめません!"
 
-#. i18n: {0} is the layer name, {1} the number of images in it
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/dialog/ChooseGeoImageLayersDialog.java#L119
-#, java-format
 msgid "{0} ({1} image)"
 msgid_plural "{0} ({1} images)"
 msgstr[0] "{0} ({1} 画像)"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageinfo/ImageInfoPanel.java#L196
-#, java-format
 msgid "{0} detections"
 msgstr "{0} 検出物"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/MapillaryLayer.java#L455
-#, java-format
 msgid "{0} downloaded image"
 msgid_plural "{0} downloaded images"
 msgstr[0] "{0} ダウンロードした画像"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/MapillaryLayer.java#L457
-#, java-format
 msgid "{0} image in total"
 msgid_plural "{0} images in total"
 msgstr[0] "全 {0} 画像"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/actions/MapillarySubmitCurrentChangesetAction.java#L88
-#, java-format
 msgid "{0} image submitted, Changeset key: {1}, State: {2}"
 msgid_plural "{0} images submitted, Changeset key: {1}, State: {2}"
 msgstr[0] "変更セットキー: {1}, 状態: {2}で、{0} この画像が送信されました。"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/MapillaryLayer.java#L463
-#, java-format
 msgid "{0} images in {1} sequences"
 msgstr "{1}シーケンス中に画像が{0}こ"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/MapillaryLayer.java#L453
-#, java-format
 msgid "{0} imported image"
 msgid_plural "{0} imported images"
 msgstr[0] "{0}このインポートした画像"
 
-#: gitlab.com/JOSM/Mapillary/blob/f52835b/src/main/java/org/openstreetmap/josm/plugins/mapillary/MapillaryLayer.java#L444
-#, java-format
 msgid "{0} sequence, containing between {1} and {2} images (ø {3})"
 msgid_plural ""
 "{0} sequences, each containing between {1} and {2} images (ø {3})"
 msgstr[0] " {1} から {2} までの画像 (ø {3})を含むシーケンス数 {0} "
 
-#. Plugin description for Mapillary
 msgid "Allows the user to work with pictures hosted at mapillary.com"
 msgstr "ユーザがmapillary.comで保持している写真で作業できるようにする"

--- a/src/main/po/lv.po
+++ b/src/main/po/lv.po
@@ -1,15 +1,15 @@
 # Translations for the JOSM plugin 'Mapillary' (lv)
-# Copyright (C) 2018 
+# Copyright (C) 2020
 # This file is distributed under the same license as the josm-plugin_Mapillary package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
-#, fuzzy
+#
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: josm-plugin_Mapillary v1.5.16-14-g82b2768\n"
+"Project-Id-Version: josm-plugin_Mapillary 1.5.20-3-ge40f8de\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-30 10:39+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"POT-Creation-Date: 2020-02-17 00:25+0000\n"
+"PO-Revision-Date: 2018-01-15 10:33+0000\n"
 "Language-Team: Latvian (https://www.transifex.com/josm/teams/2544/lv/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -22,6 +22,10 @@ msgstr "2 attēli apvienoti"
 
 msgid "2 images unjoined"
 msgstr "2 attēli atvienoti"
+
+msgid ""
+"A tag with key <i>{0}</i> is already present on the selected OSM object."
+msgstr "Tags ar atslēgu <i>{0}</i> jau atrodas uz izvēlētā OSM objekta."
 
 msgid "Add Mapillary tag"
 msgstr "Pievienot Mapillary tagu"
@@ -45,7 +49,12 @@ msgstr ""
 msgid "Cancel"
 msgstr "Atcelt"
 
-#, java-format
+msgid ""
+"Center view on new image when using the buttons to jump to another image"
+msgstr ""
+"Centrēt skatu uz jauna attēla, kad tiek izmantotas pogas lai pārlektu uz "
+"citu attēlu"
+
 msgid "Changeset upload failed with {0} error ''{1} {2}''!"
 msgstr "Izmaiņu augšupielāde neizdevās ar {0} kļūdu ''{1} {2}''!"
 
@@ -61,28 +70,26 @@ msgstr "Kopēt atslēgu"
 msgid "Could not import a geotagged image to the Mapillary layer!"
 msgstr "Neizdevās importēt ģeotagotu attēlu Mapillary slānī!"
 
-#, java-format
 msgid "Could not import the directory ''{0}''!"
 msgstr "Nevarēja importēt mapi ''{0}''!"
 
-#, java-format
 msgid "Could not import the image ''{0}''!"
 msgstr "Nevarēja importēt attēlu ''{0}''!"
 
-#, java-format
 msgid "Could not open the URL {0} in a browser"
 msgstr "Nevarēja atvērt URL {0} pārlūkprogrammā"
 
-#, java-format
 msgid "Could not read from URL {0}!"
 msgstr "Nevarēja nolasīt no URL {0}!"
 
 msgid "Current Mapillary changeset"
 msgstr "Pašreizējais Mapillary izmaiņu klāsts "
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Cut off sequences at download bounds"
 msgstr "Nogriezt sekvences pie lejupielādes robežām"
+
+msgid "Dark mode for image display"
+msgstr "Tumšais režīms attēlu rādīšanai"
 
 msgid "Days"
 msgstr "Dienas"
@@ -90,14 +97,12 @@ msgstr "Dienas"
 msgid "Delete after upload"
 msgstr "Izdzēst pēc augšupielādes"
 
-#, java-format
 msgid "Deleted {0} image"
 msgid_plural "Deleted {0} images"
 msgstr[0] "Izdzēsa {0} attēlus"
 msgstr[1] "Izdzēsa {0} attēlu"
 msgstr[2] "Izdzēsa {0} attēlus"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Display hour when the picture was taken"
 msgstr "Parādīt stundu kad attēls tika uzņemts"
 
@@ -110,7 +115,6 @@ msgstr "Parāda objektus, kurus Mapillary atrada savos ielu attēlos "
 msgid "Displays the layer displaying the map objects detected by Mapillary"
 msgstr "Parāda slāni, kurā redzami Mapillary atrastie kartes objekti"
 
-#, java-format
 msgid ""
 "Do you really want to replace the current value <i>{0}</i> with the new "
 "value <i>{1}</i>?"
@@ -139,7 +143,6 @@ msgstr "Lejupielādē kartes objektus..."
 msgid "Downloading…"
 msgstr "Lejupielādē..."
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Enable experimental beta-features (might be unstable)"
 msgstr "Iespējot eksperimentālās beta iespējas (var būt nestabilas)"
 
@@ -154,6 +157,9 @@ msgstr "Eksportēt visus attēlus"
 
 msgid "Export selected images"
 msgstr "Eksportēt izvēlētos attēlus"
+
+msgid "Export selected sequence"
+msgstr "Eksportēt izvēlēto sekvenci"
 
 msgid "Exporting Mapillary Images…"
 msgstr "Eksportē Mapillary Attēlus.."
@@ -170,11 +176,17 @@ msgstr "No esošā attēlu slāņa"
 msgid "From which source do you want to import images to the Mapillary layer?"
 msgstr "No kura avota jūs gribat importēt attēlus Mapillary slānī?"
 
+msgid "Give way"
+msgstr "Dodiet Ceļu"
+
 msgid "Go to setting and log in to Mapillary before uploading."
 msgstr "Ieej iestatījumos un ieej Mapillary pirms augšupielādes."
 
 msgid "I got it, close this."
 msgstr "Es saprotu, aizver šo."
+
+msgid "Image actions"
+msgstr "Attēlu opcijas"
 
 msgid "Image detections"
 msgstr "Attēla noteikšana"
@@ -205,6 +217,12 @@ msgstr "Importēt attēlus Mapillary slānī"
 
 msgid "Imported images"
 msgstr "Importētie attēli"
+
+msgid "Imported {0} image"
+msgid_plural "Imported {0} images"
+msgstr[0] "Importēja {0} attēlus"
+msgstr[1] "Importēja {0} attēlu"
+msgstr[2] "Importēja {0} attēlus"
 
 msgid "Join mode"
 msgstr "Savienošanas režīms"
@@ -269,7 +287,6 @@ msgstr "Mapillary objekti"
 msgid "Months"
 msgstr "Mēneši"
 
-#, java-format
 msgid "Moved {0} image"
 msgid_plural "Moved {0} images"
 msgstr[0] "Pārvietoja {0} attēlus"
@@ -279,11 +296,11 @@ msgstr[2] "Pārvietoja {0} attēlus"
 msgid "Next picture"
 msgstr "Nākamais attēls"
 
-msgid "No image selected"
-msgstr "Nav izvēlēts neviens attēls"
-
 msgid "No images found"
 msgstr "Nav atrasts neviens attēls"
+
+msgid "No overtaking"
+msgstr "Apdzīt aizliegts"
 
 msgid "Only images with signs"
 msgstr "Tikai attēlus ar ceļazīmēm"
@@ -309,12 +326,14 @@ msgstr "Pauzēt"
 msgid "Pauses the walk."
 msgstr "Apstādina iešanu."
 
-#. i18n: traffic sign
 msgid "Pedestrian crossing"
 msgstr "Gājēju pāreja"
 
 msgid "Play"
 msgstr "Atskaņot"
+
+msgid "Press \"{0}\" to download images"
+msgstr "Nospied \"{0}\" lai lejupielādētu attēlus"
 
 msgid "Previous picture"
 msgstr "Iepriekšējais attēls"
@@ -334,7 +353,6 @@ msgstr "Izvēlies attēlus, kurus tu gribi importēt"
 msgid "Show detections on top of image"
 msgstr "Rādīt atrastos objektus virs attēlus"
 
-#. i18n: traffic sign
 msgid "Speed limit"
 msgstr "Braukšanas ātrums"
 
@@ -342,7 +360,6 @@ msgctxt "as synonym to halt or stand still"
 msgid "Stop"
 msgstr "Stop"
 
-#. i18n: traffic sign
 msgctxt "name of the traffic sign"
 msgid "Stop"
 msgstr "Stop"
@@ -356,7 +373,6 @@ msgstr "Augšupielādēt izmaiņas"
 msgid "Submit the current changeset"
 msgstr "Augšupielādēt pašreizējās izmaiņas"
 
-#. CHECKSTYLE.OFF: LineLength
 msgid "Submit the current changeset to Mapillary"
 msgstr "Augšupielādēt pašreizējās izmaiņas uz Mapillary"
 
@@ -385,11 +401,9 @@ msgstr "Pašlaik nav slāņu ar ģeotagotiem attēliem!"
 msgid "Too many map objects, zoom in to see all."
 msgstr "Pārāk daudz kartes objektu, pietuvini lai redzētu visus."
 
-#, java-format
 msgid "Total Mapillary images: {0}"
 msgstr "Kopējie Mapillary attēli: {0}"
 
-#, java-format
 msgid "Turned {0} image"
 msgid_plural "Turned {0} images"
 msgstr[0] "Pagrieza {0} attēlus"
@@ -399,7 +413,6 @@ msgstr[2] "Pagrieza {0} attēlus"
 msgid "Undo"
 msgstr "Atsaukt"
 
-#. i18n: traffic sign
 msgid "Uneven road"
 msgstr "Nelīdzens ceļš"
 
@@ -412,11 +425,9 @@ msgstr "Augšupielādēt Mapillary attēlus"
 msgid "Upload selected sequence"
 msgstr "Augšupielādējiet izvēlēto sekvenci"
 
-#, java-format
 msgid "Uploading: {0}"
 msgstr "Augšupielādē: {0}"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Use 24 hour format"
 msgstr "Izmantot 24 stundu laika formātu"
 
@@ -437,7 +448,6 @@ msgstr ""
 "Iešanas režīms: Iešana līdz nākamajam attēlam aizņem pārāk ilgi! Izejam no "
 "iešanas režīma..."
 
-#. i18n: Checkbox label in JOSM settings
 msgid ""
 "When opening Mapillary image in web browser, show the blur editor instead of"
 " the image viewer"
@@ -454,7 +464,6 @@ msgstr "Gadi"
 msgid "You are currently not logged in."
 msgstr "Tu neesi ierakstījies."
 
-#, java-format
 msgid "You are logged in as ''{0}''."
 msgstr "Tu esi ienācis kā ''{0}''."
 
@@ -482,7 +491,6 @@ msgstr "atteikts"
 msgid "unknown user"
 msgstr "nezināms lietotājs"
 
-#, java-format
 msgid ""
 "{0}\n"
 "Could not read map objects from URL\n"
@@ -492,39 +500,32 @@ msgstr ""
 "Nevarēja nolasīt kartes objektus no URL\n"
 "{1}!"
 
-#. i18n: {0} is the layer name, {1} the number of images in it
-#, java-format
 msgid "{0} ({1} image)"
 msgid_plural "{0} ({1} images)"
 msgstr[0] "{0} ({1} attēli)"
 msgstr[1] "{0} ({1} attēls)"
 msgstr[2] "{0} ({1} attēli)"
 
-#, java-format
 msgid "{0} detections"
 msgstr "{0} izdzēsti"
 
-#, java-format
 msgid "{0} downloaded image"
 msgid_plural "{0} downloaded images"
 msgstr[0] "{0} lejupielādēti attēli"
 msgstr[1] "{0} lejupielādēts attēls"
 msgstr[2] "{0} lejupielādēti attēli"
 
-#, java-format
 msgid "{0} image in total"
 msgid_plural "{0} images in total"
 msgstr[0] "{0} attēli kopumā"
 msgstr[1] "{0} attēls kopumā"
 msgstr[2] "{0} attēli kopumā"
 
-#, java-format
 msgid "{0} imported image"
 msgid_plural "{0} imported images"
 msgstr[0] "{0} importētu attēlu"
 msgstr[1] "{0} importēts attēls"
 msgstr[2] "{0} importēti attēli"
 
-#. Plugin description for Mapillary
 msgid "Allows the user to work with pictures hosted at mapillary.com"
 msgstr "Ļauj lietotājam strādāt ar attēliem no mapillary.com"

--- a/src/main/po/nl.po
+++ b/src/main/po/nl.po
@@ -1,15 +1,15 @@
 # Translations for the JOSM plugin 'Mapillary' (nl)
-# Copyright (C) 2018 
+# Copyright (C) 2020
 # This file is distributed under the same license as the josm-plugin_Mapillary package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
-#, fuzzy
+#
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: josm-plugin_Mapillary v1.5.16-14-g82b2768\n"
+"Project-Id-Version: josm-plugin_Mapillary 1.5.20-3-ge40f8de\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-30 10:39+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"POT-Creation-Date: 2020-02-17 00:25+0000\n"
+"PO-Revision-Date: 2018-01-15 10:33+0000\n"
 "Language-Team: Dutch (https://www.transifex.com/josm/teams/2544/nl/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -23,7 +23,6 @@ msgstr "2 afbeeldingen samengevoegd"
 msgid "2 images unjoined"
 msgstr "2 afbeeldingen van elkaar losgemaakt"
 
-#, java-format
 msgid ""
 "A tag with key <i>{0}</i> is already present on the selected OSM object."
 msgstr ""
@@ -54,7 +53,6 @@ msgstr ""
 msgid "Cancel"
 msgstr "Annuleren"
 
-#, java-format
 msgid "Changeset upload failed with {0} error ''{1} {2}''!"
 msgstr "Uploaden van wijzigingenset mislukt met {0} fout ''{1} {2}''!"
 
@@ -71,26 +69,21 @@ msgid "Could not import a geotagged image to the Mapillary layer!"
 msgstr ""
 "Kon geen afbeelding met geoverwijzingen importeren in de laag van Mapillary!"
 
-#, java-format
 msgid "Could not import the directory ''{0}''!"
 msgstr "Kon de map ''{0}'' niet importeren!"
 
-#, java-format
 msgid "Could not import the image ''{0}''!"
 msgstr "Kon de afbeelding ''{0}'' niet importeren!"
 
-#, java-format
 msgid "Could not open the URL {0} in a browser"
 msgstr "Kon de URL {0} niet openen in een browser"
 
-#, java-format
 msgid "Could not read from URL {0}!"
 msgstr "Kon niet lezen vanuit de URL {0}!"
 
 msgid "Current Mapillary changeset"
 msgstr "Huidige wijzigingenset voor Mapillary"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Cut off sequences at download bounds"
 msgstr "Snijd reeksen af op de randen van de download"
 
@@ -100,13 +93,11 @@ msgstr "Dagen"
 msgid "Delete after upload"
 msgstr "Na uploaden verwijderen"
 
-#, java-format
 msgid "Deleted {0} image"
 msgid_plural "Deleted {0} images"
 msgstr[0] "{0} afbeelding verwijderd"
 msgstr[1] "{0} afbeeldingen verwijderd"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Display hour when the picture was taken"
 msgstr "Uur weergeven van wanneer de afbeelding werd gemaakt"
 
@@ -125,7 +116,6 @@ msgstr ""
 "Geeft de laag weer die de kaartobjecten weergeeft die zijn gedetecteerd door"
 " Mapillary"
 
-#, java-format
 msgid ""
 "Do you really want to replace the current value <i>{0}</i> with the new "
 "value <i>{1}</i>?"
@@ -151,7 +141,6 @@ msgstr "Downloaden van kaartobjecten is mislukt!"
 msgid "Downloading map objects…"
 msgstr "Kaartobjecten downloaden…"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Enable experimental beta-features (might be unstable)"
 msgstr "Experimentele bèta-mogelijkheden inschakelen (kunnen onstabiel zijn)"
 
@@ -180,7 +169,6 @@ msgid "From which source do you want to import images to the Mapillary layer?"
 msgstr ""
 "Vanuit welke bron wilt u afbeeldingen importeren naar de laag van Mapillary?"
 
-#. i18n: traffic sign
 msgid "Give way"
 msgstr "Voorrang verlenen"
 
@@ -226,13 +214,11 @@ msgstr "Afbeeldingen naar laag van Mapillary importeren"
 msgid "Imported images"
 msgstr "Geïmporteerde afbeeldingen"
 
-#, java-format
 msgid "Imported {0} image"
 msgid_plural "Imported {0} images"
 msgstr[0] "{0} afbeelding geïmporteerd"
 msgstr[1] "{0} afbeeldingen geïmporteerd"
 
-#. i18n: traffic sign
 msgid "Intersection danger"
 msgstr "Gevaar: kruising"
 
@@ -274,7 +260,6 @@ msgstr "Log-in succesvol, terug naar JOSM."
 msgid "Logout"
 msgstr "Uitloggen"
 
-#. i18n: traffic sign
 msgid "Mandatory direction (any)"
 msgstr "Verplichte rijrivchting (altijd)"
 
@@ -308,7 +293,6 @@ msgstr "Objecten van Mapillary"
 msgid "Months"
 msgstr "Maanden"
 
-#, java-format
 msgid "Moved {0} image"
 msgid_plural "Moved {0} images"
 msgstr[0] "{0} afbeelding verplaatst"
@@ -317,32 +301,24 @@ msgstr[1] "{0} afbeeldingen verplaatst"
 msgid "Next picture"
 msgstr "Volgende afbeelding"
 
-#. i18n: traffic sign
 msgid "No entry"
 msgstr "Niet inrijden"
-
-msgid "No image selected"
-msgstr "Geen afbeelding geselecteerd"
 
 msgid "No images found"
 msgstr "Geen afbeeldingen gevonden"
 
-#. i18n: traffic sign
 msgid "No overtaking"
 msgstr "Niet inhalen"
 
-#. i18n: traffic sign
 msgid "No parking"
 msgstr "Niet parkeren"
 
-#. i18n: traffic sign
 msgid "No turn"
 msgstr "Niet keren"
 
 msgid "Not older than: "
 msgstr "Niet ouder dan: "
 
-#. i18n: Spinner label in JOSM settings
 msgid "Number of images to be pre-fetched (forwards and backwards)"
 msgstr ""
 "Aantal afbeeldingen om vooraf op te halen (voorwaarts en achterwaarts)"
@@ -368,18 +344,15 @@ msgstr "Pauze"
 msgid "Pauses the walk."
 msgstr "Onderbreekt de wandeling"
 
-#. i18n: traffic sign
 msgid "Pedestrian crossing"
 msgstr "Voetgangersoversteekplaats"
 
 msgid "Play"
 msgstr "Afspelen"
 
-#, java-format
 msgid "Press \"{0}\" to download images"
 msgstr "Druk op \"{0}\" om afbeeldingen te downloaden"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Preview images when hovering its icon"
 msgstr "Voorbeeld van afbeeldingen bij bevinden boven pictogram"
 
@@ -395,7 +368,6 @@ msgstr "Herstellen"
 msgid "Rewrite imported images"
 msgstr "Geïmporteerde afbeeldingen opnieuw schrijven"
 
-#. i18n: traffic sign
 msgid "Roundabout"
 msgstr "Rotonde"
 
@@ -423,7 +395,6 @@ msgstr "Geeft de volgende afbeelding in de reeks weer"
 msgid "Shows the previous picture in the sequence"
 msgstr "Geeft de vorige afbeelding in de reeks weer"
 
-#. i18n: traffic sign
 msgid "Speed limit"
 msgstr "Maximum snelheid"
 
@@ -431,7 +402,6 @@ msgctxt "as synonym to halt or stand still"
 msgid "Stop"
 msgstr "Stop"
 
-#. i18n: traffic sign
 msgctxt "name of the traffic sign"
 msgid "Stop"
 msgstr "Stop"
@@ -445,7 +415,6 @@ msgstr "Wijzigingenset indienen"
 msgid "Submit the current changeset"
 msgstr "De huidige wijzigingenset indienen"
 
-#. CHECKSTYLE.OFF: LineLength
 msgid "Submit the current changeset to Mapillary"
 msgstr "De huidige wijzigingenset naar Mapillary indienen"
 
@@ -481,7 +450,6 @@ msgstr ""
 msgid "There are currently no layers with geotagged images!"
 msgstr "Er zijn momenteel geen lagen met afbeeldingen met geoverwijzingen!"
 
-#, java-format
 msgid ""
 "To solve this problem, you could switch to download mode ''{0}'' and load "
 "Mapillary images for a smaller portion of the map."
@@ -499,11 +467,9 @@ msgstr ""
 msgid "Too many map objects, zoom in to see all."
 msgstr "Teveel kaartobjecten, zoom in om ze allemaal te zien."
 
-#, java-format
 msgid "Total Mapillary images: {0}"
 msgstr "Totaal aantal afbeeldingen van Mapillary: {0}"
 
-#, java-format
 msgid "Turned {0} image"
 msgid_plural "Turned {0} images"
 msgstr[0] "{0} afbeelding gedraaid"
@@ -512,7 +478,6 @@ msgstr[1] "{0} afbeeldingen gedraaid"
 msgid "Undo"
 msgstr "Ongedaan maken"
 
-#. i18n: traffic sign
 msgid "Uneven road"
 msgstr "Oneven weg"
 
@@ -525,11 +490,9 @@ msgstr "Afbeeldingen van Mapillary uploaden"
 msgid "Upload selected sequence"
 msgstr "Geselecteerde reeks uploaden"
 
-#, java-format
 msgid "Uploading: {0}"
 msgstr "Uploaden: {0}"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Use 24 hour format"
 msgstr "24-uursindeling gebruiken"
 
@@ -554,7 +517,6 @@ msgstr "Jaren"
 msgid "You are currently not logged in."
 msgstr "U bent momenteel niet ingelogd."
 
-#, java-format
 msgid "You are logged in as ''{0}''."
 msgstr "U bent aangemeld als ''{0}''."
 
@@ -570,18 +532,15 @@ msgstr "Zoom naar huidige geselecteerde afbeelding van Mapillary"
 msgid "approved"
 msgstr "goedgekeurd"
 
-#. i18n: download mode for Mapillary images
 msgid "areas with downloaded OSM-data"
 msgstr "gebieden met gedownloade gegevens van OSM"
 
-#. i18n: download mode for Mapillary images
 msgid "everything in the visible area"
 msgstr "alles in het zichtbare gebied"
 
 msgid "image has no key"
 msgstr "afbeelding heeft geen sleutel"
 
-#. i18n: download mode for Mapillary images
 msgid "only when manually requested"
 msgstr "alleen indien handmatig verzocht"
 
@@ -597,7 +556,6 @@ msgstr "reeks heeft geen sleutel"
 msgid "unknown user"
 msgstr "onbekende gebruiker"
 
-#, java-format
 msgid ""
 "{0}\n"
 "Could not read map objects from URL\n"
@@ -607,15 +565,12 @@ msgstr ""
 "Kon geen kaartobjecten lezen vanuit URL\n"
 "{1}!"
 
-#, java-format
 msgid "{0} detections"
 msgstr "{0} detecties"
 
-#, java-format
 msgid "{0} images in {1} sequences"
 msgstr "{0} afbeeldingen in {1} reeksen"
 
-#. Plugin description for Mapillary
 msgid "Allows the user to work with pictures hosted at mapillary.com"
 msgstr ""
 "Stelt de gebruiker in staat om te werken met afbeeldingen die worden gehost "

--- a/src/main/po/pl.po
+++ b/src/main/po/pl.po
@@ -1,15 +1,15 @@
 # Translations for the JOSM plugin 'Mapillary' (pl)
-# Copyright (C) 2018 
+# Copyright (C) 2020
 # This file is distributed under the same license as the josm-plugin_Mapillary package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
-#, fuzzy
+#
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: josm-plugin_Mapillary v1.5.16-14-g82b2768\n"
+"Project-Id-Version: josm-plugin_Mapillary 1.5.20-3-ge40f8de\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-30 10:39+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"POT-Creation-Date: 2020-02-17 00:25+0000\n"
+"PO-Revision-Date: 2018-01-15 10:33+0000\n"
 "Language-Team: Polish (https://www.transifex.com/josm/teams/2544/pl/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -23,7 +23,6 @@ msgstr "2 zdjęcia połączone"
 msgid "2 images unjoined"
 msgstr "2 zdjęcia rozłączone"
 
-#, java-format
 msgid ""
 "A tag with key <i>{0}</i> is already present on the selected OSM object."
 msgstr ""
@@ -52,7 +51,12 @@ msgstr ""
 msgid "Cancel"
 msgstr "Anuluj"
 
-#, java-format
+msgid ""
+"Center view on new image when using the buttons to jump to another image"
+msgstr ""
+"Wyśrodkuj widok na nowym obrazie po użyciu przycisków przeskakiwania do "
+"innego obrazu"
+
 msgid "Changeset upload failed with {0} error ''{1} {2}''!"
 msgstr "Błąd wysyłania zestawu zmian z {0} ''{1} {2}''!"
 
@@ -69,28 +73,26 @@ msgid "Could not import a geotagged image to the Mapillary layer!"
 msgstr ""
 "Nie można zaimportować zdjęc z zapisaną pozycją GPS do warstwy Mapillary."
 
-#, java-format
 msgid "Could not import the directory ''{0}''!"
 msgstr "Nie można zaimportować katalogu ''{0}''!"
 
-#, java-format
 msgid "Could not import the image ''{0}''!"
 msgstr "Nie można zaimportować zdjęcia ''{0}''!"
 
-#, java-format
 msgid "Could not open the URL {0} in a browser"
 msgstr "Nie można otworzyć adresu URL {0} w przeglądarce"
 
-#, java-format
 msgid "Could not read from URL {0}!"
 msgstr "Nie można odczytać z URL {0}!"
 
 msgid "Current Mapillary changeset"
 msgstr "Obecny zestaw zmian Mapillary"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Cut off sequences at download bounds"
 msgstr "Obetnij sekwencje na granicach pobierania"
+
+msgid "Dark mode for image display"
+msgstr "Tryb ciemny w wyświetlaniu obrazów"
 
 msgid "Days"
 msgstr "Dni"
@@ -98,7 +100,6 @@ msgstr "Dni"
 msgid "Delete after upload"
 msgstr "Usuń po wysłaniu"
 
-#, java-format
 msgid "Deleted {0} image"
 msgid_plural "Deleted {0} images"
 msgstr[0] "Usunięto {0} obraz"
@@ -106,7 +107,6 @@ msgstr[1] "Usunięto {0} obrazy"
 msgstr[2] "Usunięto {0} obrazów"
 msgstr[3] "Usunięto {0} obrazów"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Display hour when the picture was taken"
 msgstr "Wyświetlaj godzinę wykonania zdjęcia."
 
@@ -119,7 +119,6 @@ msgstr "Wyświetla obiekty wykryte przez Mapillary z ich podkładu street view"
 msgid "Displays the layer displaying the map objects detected by Mapillary"
 msgstr "Wyświetla warstwę pokazującą obiekty na mapie wykryte przez Mapillary"
 
-#, java-format
 msgid ""
 "Do you really want to replace the current value <i>{0}</i> with the new "
 "value <i>{1}</i>?"
@@ -146,7 +145,6 @@ msgstr "Pobieranie elementów mapy…"
 msgid "Downloading…"
 msgstr "Pobieranie..."
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Enable experimental beta-features (might be unstable)"
 msgstr "Włącz tryb eksperymentalny (może być niestabilny)"
 
@@ -180,7 +178,6 @@ msgstr "Z istniejącej warstwy zdjęć"
 msgid "From which source do you want to import images to the Mapillary layer?"
 msgstr "Z jakiego źródła chcesz zaimportować zdjęcia do warstwy Mapillary?"
 
-#. i18n: traffic sign
 msgid "Give way"
 msgstr "Ustąp pierwszeństwa"
 
@@ -226,7 +223,6 @@ msgstr "Importuj zdjęcia na warstwę Mapillary"
 msgid "Imported images"
 msgstr "Zaimportowane obrazy"
 
-#, java-format
 msgid "Imported {0} image"
 msgid_plural "Imported {0} images"
 msgstr[0] "Zaimportowano {0} obraz"
@@ -234,7 +230,6 @@ msgstr[1] "Zaimportowano {0} obrazy"
 msgstr[2] "Zaimportowano {0} obrazów"
 msgstr[3] "Zaimportowano {0} obrazów"
 
-#. i18n: traffic sign
 msgid "Intersection danger"
 msgstr "Niebezpieczne skrzyżowanie"
 
@@ -276,7 +271,6 @@ msgstr "Zalogowano pomyślnie, powrót do JOSM."
 msgid "Logout"
 msgstr "Wyloguj"
 
-#. i18n: traffic sign
 msgid "Mandatory direction (any)"
 msgstr "Obowiązkowy kierunek (dowolny)"
 
@@ -313,7 +307,6 @@ msgstr "Obiekty Mapillary"
 msgid "Months"
 msgstr "Miesiące"
 
-#, java-format
 msgid "Moved {0} image"
 msgid_plural "Moved {0} images"
 msgstr[0] "Przesunięto {0} obraz"
@@ -324,25 +317,18 @@ msgstr[3] "Przesunięto {0} obrazów"
 msgid "Next picture"
 msgstr "Następne zdjęcie"
 
-#. i18n: traffic sign
 msgid "No entry"
 msgstr "Zakaz wjazdu"
-
-msgid "No image selected"
-msgstr "Nie wybrano obrazu"
 
 msgid "No images found"
 msgstr "Nie znaleziono zdjęć"
 
-#. i18n: traffic sign
 msgid "No overtaking"
 msgstr "Zakaz wyprzedzania"
 
-#. i18n: traffic sign
 msgid "No parking"
 msgstr "Zakaz postoju"
 
-#. i18n: traffic sign
 msgid "No turn"
 msgstr "Zakaz zawracania"
 
@@ -352,7 +338,6 @@ msgstr "Niezalogowany do Mapillary"
 msgid "Not older than: "
 msgstr "Nie starsze niż: "
 
-#. i18n: Spinner label in JOSM settings
 msgid "Number of images to be pre-fetched (forwards and backwards)"
 msgstr "Ilość obrazów które mają być wstępnie pobrane (do przodu i tyłu)"
 
@@ -380,18 +365,15 @@ msgstr "Zatrzymaj"
 msgid "Pauses the walk."
 msgstr "Zatrzymuje spacer."
 
-#. i18n: traffic sign
 msgid "Pedestrian crossing"
 msgstr "Przejście dla pieszych"
 
 msgid "Play"
 msgstr "Idź"
 
-#, java-format
 msgid "Press \"{0}\" to download images"
 msgstr "Wciśnij \"{0}\" aby pobrać obrazy"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Preview images when hovering its icon"
 msgstr "Podgląd zdjęć po najechaniu na ich ikonę"
 
@@ -407,7 +389,6 @@ msgstr "Przywróć domyślne"
 msgid "Rewrite imported images"
 msgstr "Przepisz zaimportowane obrazy"
 
-#. i18n: traffic sign
 msgid "Roundabout"
 msgstr "Rondo"
 
@@ -435,7 +416,6 @@ msgstr "Pokazuje następne zdjęcie w sekwencji"
 msgid "Shows the previous picture in the sequence"
 msgstr "Pokazuje poprzednie zdjęcie w sekwencji"
 
-#. i18n: traffic sign
 msgid "Speed limit"
 msgstr "Ograniczenie prędkości"
 
@@ -443,7 +423,6 @@ msgctxt "as synonym to halt or stand still"
 msgid "Stop"
 msgstr "Znak stop"
 
-#. i18n: traffic sign
 msgctxt "name of the traffic sign"
 msgid "Stop"
 msgstr "Znak stop"
@@ -457,7 +436,6 @@ msgstr "Zatwierdź zestaw zmian"
 msgid "Submit the current changeset"
 msgstr "Zatwierdź obecny zestaw zmian"
 
-#. CHECKSTYLE.OFF: LineLength
 msgid "Submit the current changeset to Mapillary"
 msgstr "Zatwierdź obecny zestaw zmian do Mapillary"
 
@@ -492,7 +470,6 @@ msgstr ""
 msgid "There are currently no layers with geotagged images!"
 msgstr "Nie ma obecnie warstw ze zdjęciami z zapisaną pozycją GPS."
 
-#, java-format
 msgid ""
 "To solve this problem, you could switch to download mode ''{0}'' and load "
 "Mapillary images for a smaller portion of the map."
@@ -509,11 +486,9 @@ msgstr ""
 msgid "Too many map objects, zoom in to see all."
 msgstr "Za dużo elementów mapy, przybliż żeby zobaczyć wszystko."
 
-#, java-format
 msgid "Total Mapillary images: {0}"
 msgstr "Łącznie obrazów Mapillary: {0}"
 
-#, java-format
 msgid "Turned {0} image"
 msgid_plural "Turned {0} images"
 msgstr[0] "Obrócono {0} obraz"
@@ -524,7 +499,6 @@ msgstr[3] "Obrócono {0} obrazów"
 msgid "Undo"
 msgstr "Cofnij"
 
-#. i18n: traffic sign
 msgid "Uneven road"
 msgstr "Koleiny"
 
@@ -537,11 +511,9 @@ msgstr "Wyślij obrazy Mapillary"
 msgid "Upload selected sequence"
 msgstr "Wyślij wybraną sekwencję"
 
-#, java-format
 msgid "Uploading: {0}"
 msgstr "Wysyłanie: {0}"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Use 24 hour format"
 msgstr "Używaj formatu 24-godzinnego."
 
@@ -562,7 +534,6 @@ msgstr ""
 "Tryb spaceru: Oczekiwanie na następny obraz zajmuje zbyt dużo czasu! Wyjście"
 " z trybu spaceru…"
 
-#. i18n: Checkbox label in JOSM settings
 msgid ""
 "When opening Mapillary image in web browser, show the blur editor instead of"
 " the image viewer"
@@ -579,14 +550,19 @@ msgstr "Lata"
 msgid "You are currently not logged in."
 msgstr "Nie jesteś zalogowany."
 
-#, java-format
 msgid "You are logged in as ''{0}''."
 msgstr "Jesteś zalogowany jako \"{0}\"."
 
 msgid "You are not logged in, please log in to Mapillary in the preferences"
 msgstr "Nie jesteś zalogowany, proszę to zrobić w ustawieniach Mapillary"
 
-#, java-format
+msgid ""
+"You are trying to upload a sequence to mapillary.com that you previously "
+"downloaded from there. That is not possible."
+msgstr ""
+"Próbujesz przesłać sekwencję do mapillary.com, którą wcześniej pobrałeś. Nie"
+" jest to możliwe."
+
 msgid "You have successfully uploaded {0} image to mapillary.com"
 msgid_plural "You have successfully uploaded {0} images to mapillary.com"
 msgstr[0] "Poprawnie przesłano {0} obraz do mapillary.com"
@@ -603,18 +579,18 @@ msgstr "Powiększ do obecnie wybranego obrazu"
 msgid "approved"
 msgstr "przyjęte"
 
-#. i18n: download mode for Mapillary images
 msgid "areas with downloaded OSM-data"
 msgstr "obszary z pobranymi danymi OSM"
 
-#. i18n: download mode for Mapillary images
 msgid "everything in the visible area"
 msgstr "wszystko w widocznym obszarze"
 
 msgid "image has no key"
 msgstr "obraz nie ma klucza"
 
-#. i18n: download mode for Mapillary images
+msgid "no image selected"
+msgstr "nie wybrano obrazu"
+
 msgid "only when manually requested"
 msgstr "tylko przy ręcznym żądaniu"
 
@@ -630,7 +606,6 @@ msgstr "sekwencja nie ma klucza"
 msgid "unknown user"
 msgstr "nieznany użytkownik"
 
-#, java-format
 msgid ""
 "{0}\n"
 "Could not read map objects from URL\n"
@@ -640,8 +615,6 @@ msgstr ""
 "Nie można odczytać elementów mapy z URL\n"
 "{1}!"
 
-#. i18n: {0} is the layer name, {1} the number of images in it
-#, java-format
 msgid "{0} ({1} image)"
 msgid_plural "{0} ({1} images)"
 msgstr[0] "{0} ({1} obraz)"
@@ -649,11 +622,9 @@ msgstr[1] "{0} ({1} obrazy)"
 msgstr[2] "{0} ({1} obrazów)"
 msgstr[3] "{0} ({1} obrazów)"
 
-#, java-format
 msgid "{0} detections"
 msgstr "{0} wykryć"
 
-#, java-format
 msgid "{0} downloaded image"
 msgid_plural "{0} downloaded images"
 msgstr[0] "{0} pobrany obraz"
@@ -661,7 +632,6 @@ msgstr[1] "{0} pobrane obrazy"
 msgstr[2] "{0} pobranych obrazów"
 msgstr[3] "{0} pobranych obrazów"
 
-#, java-format
 msgid "{0} image in total"
 msgid_plural "{0} images in total"
 msgstr[0] "{0} obraz łącznie"
@@ -669,7 +639,6 @@ msgstr[1] "{0} obrazy łącznie"
 msgstr[2] "{0} obrazów łącznie"
 msgstr[3] "{0} obrazów łącznie"
 
-#, java-format
 msgid "{0} image submitted, Changeset key: {1}, State: {2}"
 msgid_plural "{0} images submitted, Changeset key: {1}, State: {2}"
 msgstr[0] "{0} obraz przesłany, Zestaw zmian: {1}, Stan: {2}"
@@ -677,11 +646,9 @@ msgstr[1] "{0} obrazy przesłane, Zestaw zmian: {1}, Stan: {2}"
 msgstr[2] "{0} obrazów przesłanych, Zestaw zmian: {1}, Stan: {2}"
 msgstr[3] "{0} obrazów przesłanych, Zestaw zmian: {1}, Stan: {2}"
 
-#, java-format
 msgid "{0} images in {1} sequences"
 msgstr "{0} obrazów w {1} sekwencjach"
 
-#, java-format
 msgid "{0} imported image"
 msgid_plural "{0} imported images"
 msgstr[0] "{0} zaimportowany obraz"
@@ -689,7 +656,6 @@ msgstr[1] "{0} zaimportowane obrazy"
 msgstr[2] "{0} zaimportowanych obrazów"
 msgstr[3] "{0} zaimportowanych obrazów"
 
-#, java-format
 msgid "{0} sequence, containing between {1} and {2} images (ø {3})"
 msgid_plural ""
 "{0} sequences, each containing between {1} and {2} images (ø {3})"
@@ -701,6 +667,5 @@ msgstr[2] ""
 msgstr[3] ""
 "{0} sekwencji, każda zawierająca pomiędzy {1} a {2} obrazów (ø {3})"
 
-#. Plugin description for Mapillary
 msgid "Allows the user to work with pictures hosted at mapillary.com"
 msgstr "Pozwala użytkownikom używać obrazów przechowywanych na mapillary.com."

--- a/src/main/po/pt.po
+++ b/src/main/po/pt.po
@@ -1,15 +1,15 @@
 # Translations for the JOSM plugin 'Mapillary' (pt)
-# Copyright (C) 2018 
+# Copyright (C) 2020
 # This file is distributed under the same license as the josm-plugin_Mapillary package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
-#, fuzzy
+#
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: josm-plugin_Mapillary v1.5.16-14-g82b2768\n"
+"Project-Id-Version: josm-plugin_Mapillary 1.5.20-3-ge40f8de\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-30 10:39+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"POT-Creation-Date: 2020-02-17 00:25+0000\n"
+"PO-Revision-Date: 2018-01-15 10:33+0000\n"
 "Language-Team: Portuguese (https://www.transifex.com/josm/teams/2544/pt/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -23,7 +23,6 @@ msgstr "2 imagens unidas"
 msgid "2 images unjoined"
 msgstr "2 imagens separadas"
 
-#, java-format
 msgid ""
 "A tag with key <i>{0}</i> is already present on the selected OSM object."
 msgstr ""
@@ -52,14 +51,12 @@ msgstr ""
 msgid "Cancel"
 msgstr "Cancelar"
 
-#. i18n: Checkbox label in JOSM settings
 msgid ""
 "Center view on new image when using the buttons to jump to another image"
 msgstr ""
 "Centrar a visualização na nova imagem ao usar os botões para saltar para "
 "outra imagem"
 
-#, java-format
 msgid "Changeset upload failed with {0} error ''{1} {2}''!"
 msgstr "O envio do conjunto de alterações falhou com {0} erro ''{1} {2}''!"
 
@@ -76,28 +73,26 @@ msgid "Could not import a geotagged image to the Mapillary layer!"
 msgstr ""
 "Não foi possível importar a imagem georreferenciada para a camada Mapillary!"
 
-#, java-format
 msgid "Could not import the directory ''{0}''!"
 msgstr "Não foi possível importar a pasta ''{0}''!"
 
-#, java-format
 msgid "Could not import the image ''{0}''!"
 msgstr "Não foi possível importar a imagem ''{0}''!"
 
-#, java-format
 msgid "Could not open the URL {0} in a browser"
 msgstr "Não foi possível abrir o URL {0} no navegador de internet"
 
-#, java-format
 msgid "Could not read from URL {0}!"
 msgstr "Não foi possível ler do URL {0}!"
 
 msgid "Current Mapillary changeset"
 msgstr "Conjunto de alterações Mapillary atual"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Cut off sequences at download bounds"
 msgstr "Cortar sequências nos limites do descarregamento"
+
+msgid "Dark mode for image display"
+msgstr "Modo escuro para visualizar imagens"
 
 msgid "Days"
 msgstr "Dias"
@@ -105,13 +100,11 @@ msgstr "Dias"
 msgid "Delete after upload"
 msgstr "Eliminar após o envio"
 
-#, java-format
 msgid "Deleted {0} image"
 msgid_plural "Deleted {0} images"
 msgstr[0] "{0} imagem eliminada"
 msgstr[1] "{0} imagens eliminadas"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Display hour when the picture was taken"
 msgstr "Mostrar a hora a que a fotografia foi tirada"
 
@@ -125,7 +118,6 @@ msgstr "Mostra objetos detetados pelo Mapillary nas imagens ao nível da rua"
 msgid "Displays the layer displaying the map objects detected by Mapillary"
 msgstr "Mostra a camada com os objetos do mapa detetados pelo Mapillary"
 
-#, java-format
 msgid ""
 "Do you really want to replace the current value <i>{0}</i> with the new "
 "value <i>{1}</i>?"
@@ -153,7 +145,6 @@ msgstr "A descarregar objetos do mapa..."
 msgid "Downloading…"
 msgstr "A descarregar…"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Enable experimental beta-features (might be unstable)"
 msgstr "Ativar funcionalidades experimentais beta (pode ser instável)"
 
@@ -187,7 +178,6 @@ msgstr "Da camada de imagens existente"
 msgid "From which source do you want to import images to the Mapillary layer?"
 msgstr "De que fontes quer importar as imagens para a camada Mapillary?"
 
-#. i18n: traffic sign
 msgid "Give way"
 msgstr "Cedência de passagem"
 
@@ -234,13 +224,11 @@ msgstr "Importar imagens para a camada Mapillary"
 msgid "Imported images"
 msgstr "Imagens importadas"
 
-#, java-format
 msgid "Imported {0} image"
 msgid_plural "Imported {0} images"
 msgstr[0] "{0} imagem importadas"
 msgstr[1] "{0} imagens importadas"
 
-#. i18n: traffic sign
 msgid "Intersection danger"
 msgstr "Cruzamento"
 
@@ -281,7 +269,6 @@ msgstr "Autenticação bem sucedida, retorne ao JOSM."
 msgid "Logout"
 msgstr "Terminar sessão"
 
-#. i18n: traffic sign
 msgid "Mandatory direction (any)"
 msgstr "Sentido obrigatório"
 
@@ -318,7 +305,6 @@ msgstr "Objetos Mapillary"
 msgid "Months"
 msgstr "Meses"
 
-#, java-format
 msgid "Moved {0} image"
 msgid_plural "Moved {0} images"
 msgstr[0] "Movida {0} imagem"
@@ -327,25 +313,18 @@ msgstr[1] "Movidas {0} imagens"
 msgid "Next picture"
 msgstr "Imagem seguinte"
 
-#. i18n: traffic sign
 msgid "No entry"
 msgstr "Sentido proibido"
-
-msgid "No image selected"
-msgstr "Nenhuma imagem selecionada"
 
 msgid "No images found"
 msgstr "Nenhuma imagem encontrada"
 
-#. i18n: traffic sign
 msgid "No overtaking"
 msgstr "Ultrapassagem proibida"
 
-#. i18n: traffic sign
 msgid "No parking"
 msgstr "Estacionamento proibido"
 
-#. i18n: traffic sign
 msgid "No turn"
 msgstr "Proibido virar"
 
@@ -355,7 +334,6 @@ msgstr "Não autenticado no Mapillary"
 msgid "Not older than: "
 msgstr "Não mais antigas que: "
 
-#. i18n: Spinner label in JOSM settings
 msgid "Number of images to be pre-fetched (forwards and backwards)"
 msgstr "Número de imagens a serem pré-carregadas (anteriores e seguintes)"
 
@@ -383,18 +361,15 @@ msgstr "Pausa"
 msgid "Pauses the walk."
 msgstr "Pausa o modo a pé"
 
-#. i18n: traffic sign
 msgid "Pedestrian crossing"
 msgstr "Passadeira"
 
 msgid "Play"
 msgstr "Iniciar"
 
-#, java-format
 msgid "Press \"{0}\" to download images"
 msgstr "Carregue em \"{0}\" para descarregar as imagens"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Preview images when hovering its icon"
 msgstr "Pré-visualizar imagens ao passar com o cursor sobre o ícone"
 
@@ -410,7 +385,6 @@ msgstr "Repor"
 msgid "Rewrite imported images"
 msgstr "Tornar a gravar as imagens importadas"
 
-#. i18n: traffic sign
 msgid "Roundabout"
 msgstr "Rotunda"
 
@@ -438,7 +412,6 @@ msgstr "Mostra a próxima imagem na sequência de imagens"
 msgid "Shows the previous picture in the sequence"
 msgstr "Mostra a imagem anterior na sequência de imagens"
 
-#. i18n: traffic sign
 msgid "Speed limit"
 msgstr "Limite de velocidade"
 
@@ -446,7 +419,6 @@ msgctxt "as synonym to halt or stand still"
 msgid "Stop"
 msgstr "Sinal de Stop"
 
-#. i18n: traffic sign
 msgctxt "name of the traffic sign"
 msgid "Stop"
 msgstr "Sinal de Stop"
@@ -460,7 +432,6 @@ msgstr "Enviar conjunto de alterações"
 msgid "Submit the current changeset"
 msgstr "Enviar conjunto de alterações atual"
 
-#. CHECKSTYLE.OFF: LineLength
 msgid "Submit the current changeset to Mapillary"
 msgstr "Enviar conjunto de alterações atual para o Mapillary"
 
@@ -495,7 +466,6 @@ msgstr ""
 msgid "There are currently no layers with geotagged images!"
 msgstr "Não existem neste momento camadas com imagens georreferenciadas!"
 
-#, java-format
 msgid ""
 "To solve this problem, you could switch to download mode ''{0}'' and load "
 "Mapillary images for a smaller portion of the map."
@@ -512,11 +482,9 @@ msgstr ""
 msgid "Too many map objects, zoom in to see all."
 msgstr "Demasiados objetos, aproxime para os ver a todos."
 
-#, java-format
 msgid "Total Mapillary images: {0}"
 msgstr "Total de imagens Mapillary: {0}"
 
-#, java-format
 msgid "Turned {0} image"
 msgid_plural "Turned {0} images"
 msgstr[0] "Virada {0} imagem"
@@ -525,7 +493,6 @@ msgstr[1] "Viradas {0} imagens"
 msgid "Undo"
 msgstr "Desfazer"
 
-#. i18n: traffic sign
 msgid "Uneven road"
 msgstr "Lomba"
 
@@ -538,11 +505,9 @@ msgstr "Enviar imagens Mapillary"
 msgid "Upload selected sequence"
 msgstr "Enviar sequência selecionada"
 
-#, java-format
 msgid "Uploading: {0}"
 msgstr "A enviar: {0}"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Use 24 hour format"
 msgstr "Usar formato 24 horas"
 
@@ -563,7 +528,6 @@ msgstr ""
 "Modo a pé: está a demorar demasiado a espera pela próxima imagem! A sair do "
 "modo a pé…"
 
-#. i18n: Checkbox label in JOSM settings
 msgid ""
 "When opening Mapillary image in web browser, show the blur editor instead of"
 " the image viewer"
@@ -580,7 +544,6 @@ msgstr "Anos"
 msgid "You are currently not logged in."
 msgstr "Neste momento não está autenticado."
 
-#, java-format
 msgid "You are logged in as ''{0}''."
 msgstr "Está autenticado como ''{0}''."
 
@@ -589,7 +552,13 @@ msgstr ""
 "Não está autenticado, por favor entre na sua conta do Mapillary nas "
 "preferências"
 
-#, java-format
+msgid ""
+"You are trying to upload a sequence to mapillary.com that you previously "
+"downloaded from there. That is not possible."
+msgstr ""
+"Está a tentar enviar uma sequência para o mapillary.com que já descarregou a"
+" partir daqui. Isso não é possível."
+
 msgid "You have successfully uploaded {0} image to mapillary.com"
 msgid_plural "You have successfully uploaded {0} images to mapillary.com"
 msgstr[0] "Enviou com sucesso {0} imagem para mapillary.com"
@@ -604,18 +573,18 @@ msgstr "Ver de perto a imagem Mapillary atualmente selecionada"
 msgid "approved"
 msgstr "aprovado"
 
-#. i18n: download mode for Mapillary images
 msgid "areas with downloaded OSM-data"
 msgstr "áreas com dados descarregados do OSM"
 
-#. i18n: download mode for Mapillary images
 msgid "everything in the visible area"
 msgstr "tudo na área visível"
 
 msgid "image has no key"
 msgstr "A imagem não tem chave"
 
-#. i18n: download mode for Mapillary images
+msgid "no image selected"
+msgstr "nenhuma imagem selecionada"
+
 msgid "only when manually requested"
 msgstr "apenas quando pedido manualmente"
 
@@ -631,7 +600,6 @@ msgstr "a sequência não tem chave"
 msgid "unknown user"
 msgstr "utilizador desconhecido"
 
-#, java-format
 msgid ""
 "{0}\n"
 "Could not read map objects from URL\n"
@@ -641,30 +609,24 @@ msgstr ""
 "Não foi possível ler os objetos do mapa do URL\n"
 "{1}!"
 
-#. i18n: {0} is the layer name, {1} the number of images in it
-#, java-format
 msgid "{0} ({1} image)"
 msgid_plural "{0} ({1} images)"
 msgstr[0] "{0} ({1} imagem)"
 msgstr[1] "{0} ({1} imagens)"
 
-#, java-format
 msgid "{0} detections"
 msgstr "{0} deteções"
 
-#, java-format
 msgid "{0} downloaded image"
 msgid_plural "{0} downloaded images"
 msgstr[0] "{0} imagem descarregada"
 msgstr[1] "{0} imagens descarregadas"
 
-#, java-format
 msgid "{0} image in total"
 msgid_plural "{0} images in total"
 msgstr[0] "{0} imagem no total"
 msgstr[1] "{0} imagens no total"
 
-#, java-format
 msgid "{0} image submitted, Changeset key: {1}, State: {2}"
 msgid_plural "{0} images submitted, Changeset key: {1}, State: {2}"
 msgstr[0] ""
@@ -672,24 +634,20 @@ msgstr[0] ""
 msgstr[1] ""
 "{0} imagens enviadas; Chave do conjunto de alterações: {1}, Estado: {2}"
 
-#, java-format
 msgid "{0} images in {1} sequences"
 msgstr "{0} imagens em {1} sequências"
 
-#, java-format
 msgid "{0} imported image"
 msgid_plural "{0} imported images"
 msgstr[0] "{0} imagem importada"
 msgstr[1] "{0} imagens importadas"
 
-#, java-format
 msgid "{0} sequence, containing between {1} and {2} images (ø {3})"
 msgid_plural ""
 "{0} sequences, each containing between {1} and {2} images (ø {3})"
 msgstr[0] "{0} sequência, contendo entre {1} e {2} imagens (ø {3})"
 msgstr[1] "{0} sequências, cada uma contendo entre {1} e {2} imagens (ø {3})"
 
-#. Plugin description for Mapillary
 msgid "Allows the user to work with pictures hosted at mapillary.com"
 msgstr ""
 "Permite usar fotografias geo-referenciadas ao nível da rua do site "

--- a/src/main/po/pt_BR.po
+++ b/src/main/po/pt_BR.po
@@ -1,15 +1,15 @@
 # Translations for the JOSM plugin 'Mapillary' (pt_BR)
-# Copyright (C) 2018 
+# Copyright (C) 2020
 # This file is distributed under the same license as the josm-plugin_Mapillary package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
-#, fuzzy
+#
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: josm-plugin_Mapillary v1.5.16-14-g82b2768\n"
+"Project-Id-Version: josm-plugin_Mapillary 1.5.20-3-ge40f8de\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-30 10:39+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"POT-Creation-Date: 2020-02-17 00:25+0000\n"
+"PO-Revision-Date: 2018-01-15 10:33+0000\n"
 "Language-Team: Portuguese (Brazil) (https://www.transifex.com/josm/teams/2544/pt_BR/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -37,7 +37,6 @@ msgstr ""
 msgid "Cancel"
 msgstr "Cancelar"
 
-#, java-format
 msgid "Changeset upload failed with {0} error ''{1} {2}''!"
 msgstr "O envio do Conjunto de Alterações falhou com {0} erro ''{1} {2}''!"
 
@@ -50,7 +49,6 @@ msgstr "Continua com a caminhada pausada."
 msgid "Current Mapillary changeset"
 msgstr "Conjunto de Alterações Mapillary atual"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Cut off sequences at download bounds"
 msgstr "Cortar as sequências de acordo com os limites de download"
 
@@ -60,13 +58,11 @@ msgstr "Dias"
 msgid "Delete after upload"
 msgstr "Excluir após o upload"
 
-#, java-format
 msgid "Deleted {0} image"
 msgid_plural "Deleted {0} images"
 msgstr[0] "Apagar {0} imagem"
 msgstr[1] "Apagar {0} imagens"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Display hour when the picture was taken"
 msgstr "Mostra hora quando a foto foi tirada"
 
@@ -85,7 +81,6 @@ msgstr "Imagens baixadas"
 msgid "Downloading Mapillary images"
 msgstr "Baixar imagens do Mapillary"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Enable experimental beta-features (might be unstable)"
 msgstr "Ativar funcionalidades beta e experimentais (pode ser instável)"
 
@@ -110,7 +105,6 @@ msgstr "Upload terminado"
 msgid "Follow selected image"
 msgstr "Seguir imagem selecionada"
 
-#. i18n: traffic sign
 msgid "Give way"
 msgstr "Dê a preferência"
 
@@ -136,13 +130,11 @@ msgstr "Importar imagens na camada do Mapillary"
 msgid "Imported images"
 msgstr "Imagens importadas"
 
-#, java-format
 msgid "Imported {0} image"
 msgid_plural "Imported {0} images"
 msgstr[0] "Importar {0} imagem"
 msgstr[1] "Importar {0} imagens"
 
-#. i18n: traffic sign
 msgid "Intersection danger"
 msgstr "Cruzamento perigoso"
 
@@ -173,7 +165,6 @@ msgstr "Login bem sucedido, retornar ao JOSM."
 msgid "Logout"
 msgstr "Logout"
 
-#. i18n: traffic sign
 msgid "Mandatory direction (any)"
 msgstr "Sentido obrigatório (qualquer)"
 
@@ -207,7 +198,6 @@ msgstr "Camada de objetos do Mapillary"
 msgid "Months"
 msgstr "Meses"
 
-#, java-format
 msgid "Moved {0} image"
 msgid_plural "Moved {0} images"
 msgstr[0] "Movida {0} imagem"
@@ -216,25 +206,18 @@ msgstr[1] "Movidas {0} imagens"
 msgid "Next picture"
 msgstr "Próxima foto"
 
-#. i18n: traffic sign
 msgid "No entry"
 msgstr "Entrada proibida"
-
-msgid "No image selected"
-msgstr "Nenhuma imagem selecionada"
 
 msgid "No images found"
 msgstr "Nenhuma imagem encontrada"
 
-#. i18n: traffic sign
 msgid "No overtaking"
 msgstr "Proibido ultrapassar"
 
-#. i18n: traffic sign
 msgid "No parking"
 msgstr "Proibido estacionar"
 
-#. i18n: traffic sign
 msgid "No turn"
 msgstr "Proibido virar"
 
@@ -265,18 +248,15 @@ msgstr "Pausar"
 msgid "Pauses the walk."
 msgstr "Pausa a caminhada."
 
-#. i18n: traffic sign
 msgid "Pedestrian crossing"
 msgstr "Travessia de pedestres"
 
 msgid "Play"
 msgstr "Tocar"
 
-#, java-format
 msgid "Press \"{0}\" to download images"
 msgstr "Pressione \"{0}\" para baixar as imagens"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Preview images when hovering its icon"
 msgstr "Pré-visualizar imagens ao passar o mouse sobre o ícone"
 
@@ -292,7 +272,6 @@ msgstr "Reiniciar"
 msgid "Rewrite imported images"
 msgstr "Reescreve imagens importadas"
 
-#. i18n: traffic sign
 msgid "Roundabout"
 msgstr "Rotatória"
 
@@ -308,7 +287,6 @@ msgstr "Mostra a próxima foto na sequência"
 msgid "Shows the previous picture in the sequence"
 msgstr "Mostra a foto anterior na sequência"
 
-#. i18n: traffic sign
 msgid "Speed limit"
 msgstr "Limite de velocidade"
 
@@ -316,7 +294,6 @@ msgctxt "as synonym to halt or stand still"
 msgid "Stop"
 msgstr "Pare"
 
-#. i18n: traffic sign
 msgctxt "name of the traffic sign"
 msgid "Stop"
 msgstr "Pare"
@@ -330,7 +307,6 @@ msgstr "Enviar o conjunto de alterações"
 msgid "Submit the current changeset"
 msgstr "Enviar o conjunto de alterações atual"
 
-#. CHECKSTYLE.OFF: LineLength
 msgid "Submit the current changeset to Mapillary"
 msgstr "Enviar o conjunto de alterações atual para a Mapillary"
 
@@ -340,11 +316,9 @@ msgstr "Enviando conjunto de alterações para o servidor..."
 msgid "Supported image formats (JPG and PNG)"
 msgstr "Formatos de imagens suportado (JPG e PNG)"
 
-#, java-format
 msgid "Total Mapillary images: {0}"
 msgstr "Total de imagens Mapillary: {0}"
 
-#, java-format
 msgid "Turned {0} image"
 msgid_plural "Turned {0} images"
 msgstr[0] "Virada {0} imagem"
@@ -353,7 +327,6 @@ msgstr[1] "Viradas {0} imagens"
 msgid "Undo"
 msgstr "Desfazer"
 
-#. i18n: traffic sign
 msgid "Uneven road"
 msgstr "Estrada irregular"
 
@@ -366,11 +339,9 @@ msgstr "Enviar imagens Mapillary"
 msgid "Upload selected sequence"
 msgstr "Enviar sequência selecionada"
 
-#, java-format
 msgid "Uploading: {0}"
 msgstr "Enviando: {0}"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Use 24 hour format"
 msgstr "Usar formato de 24 horas"
 
@@ -383,7 +354,6 @@ msgstr "Espere por imagens de qualidade total"
 msgid "Walk mode"
 msgstr "Modo caminhada"
 
-#. i18n: Checkbox label in JOSM settings
 msgid ""
 "When opening Mapillary image in web browser, show the blur editor instead of"
 " the image viewer"
@@ -397,7 +367,6 @@ msgstr "Anos"
 msgid "You are currently not logged in."
 msgstr "No momento você não está logado."
 
-#, java-format
 msgid "You are logged in as ''{0}''."
 msgstr "Você está logado como ''{0}''."
 
@@ -416,10 +385,8 @@ msgstr "pendente"
 msgid "rejected"
 msgstr "rejeitado"
 
-#, java-format
 msgid "{0} images in {1} sequences"
 msgstr "{0} imagens em {1} sequências"
 
-#. Plugin description for Mapillary
 msgid "Allows the user to work with pictures hosted at mapillary.com"
 msgstr "Permite o usuário trabalhar com imagens hospedadas em mapillary.com"

--- a/src/main/po/ru.po
+++ b/src/main/po/ru.po
@@ -1,15 +1,15 @@
 # Translations for the JOSM plugin 'Mapillary' (ru)
-# Copyright (C) 2018 
+# Copyright (C) 2020
 # This file is distributed under the same license as the josm-plugin_Mapillary package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
-#, fuzzy
+#
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: josm-plugin_Mapillary v1.5.16-14-g82b2768\n"
+"Project-Id-Version: josm-plugin_Mapillary 1.5.20-3-ge40f8de\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-30 10:39+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"POT-Creation-Date: 2020-02-17 00:25+0000\n"
+"PO-Revision-Date: 2018-01-15 10:33+0000\n"
 "Language-Team: Russian (https://www.transifex.com/josm/teams/2544/ru/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -23,7 +23,6 @@ msgstr "2 снимка соединены"
 msgid "2 images unjoined"
 msgstr "2 снимка разъединены"
 
-#, java-format
 msgid ""
 "A tag with key <i>{0}</i> is already present on the selected OSM object."
 msgstr "Тег с ключом <i>{0}</i> уже есть у выделенного объекта OSM."
@@ -51,7 +50,6 @@ msgstr ""
 msgid "Cancel"
 msgstr "Отменить"
 
-#, java-format
 msgid "Changeset upload failed with {0} error ''{1} {2}''!"
 msgstr ""
 "Не удалось отправить пакет правок по версии протокола {0} с ошибкой: ''{1} "
@@ -69,26 +67,21 @@ msgstr "Копировать ID"
 msgid "Could not import a geotagged image to the Mapillary layer!"
 msgstr "Не удалось импортировать геотегированный снимок в слой Mapillary!"
 
-#, java-format
 msgid "Could not import the directory ''{0}''!"
 msgstr "Не удалось импортировать каталог ''{0}''!"
 
-#, java-format
 msgid "Could not import the image ''{0}''!"
 msgstr "Не удалось импортировать изображение ''{0}''!"
 
-#, java-format
 msgid "Could not open the URL {0} in a browser"
 msgstr "Не удалось открыть URL {0} в браузере"
 
-#, java-format
 msgid "Could not read from URL {0}!"
 msgstr "Не удалось выполнить чтение из URL {0}!"
 
 msgid "Current Mapillary changeset"
 msgstr "Текущий  пакет правок Mapillary"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Cut off sequences at download bounds"
 msgstr "Обрезать последовательности по границам скачанной области"
 
@@ -98,7 +91,6 @@ msgstr "дней"
 msgid "Delete after upload"
 msgstr "Удалить после отправки"
 
-#, java-format
 msgid "Deleted {0} image"
 msgid_plural "Deleted {0} images"
 msgstr[0] "Удалён {0} снимок"
@@ -106,7 +98,6 @@ msgstr[1] "Удалены {0} снимка"
 msgstr[2] "Удалено {0} снимков"
 msgstr[3] "Удалено {0} снимка"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Display hour when the picture was taken"
 msgstr "Показывать время, когда был сделан снимок"
 
@@ -119,7 +110,6 @@ msgstr "Отображает объекты, обнаруженные Mapillary 
 msgid "Displays the layer displaying the map objects detected by Mapillary"
 msgstr "Отображает слой с объектами карты, обнаруженными Mapillary"
 
-#, java-format
 msgid ""
 "Do you really want to replace the current value <i>{0}</i> with the new "
 "value <i>{1}</i>?"
@@ -148,7 +138,6 @@ msgstr "Скачивание объектов карты…"
 msgid "Downloading…"
 msgstr "Загрузка…"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Enable experimental beta-features (might be unstable)"
 msgstr "Включить экспериментальные функции (могут быть нестабильными)"
 
@@ -183,7 +172,6 @@ msgid "From which source do you want to import images to the Mapillary layer?"
 msgstr ""
 "Из какого источника вы хотите импортировать изображения в слой Mapillary?"
 
-#. i18n: traffic sign
 msgid "Give way"
 msgstr "Уступите дорогу"
 
@@ -229,7 +217,6 @@ msgstr "Импортировать изображения на слой Mapillar
 msgid "Imported images"
 msgstr "Импортированные изображения"
 
-#, java-format
 msgid "Imported {0} image"
 msgid_plural "Imported {0} images"
 msgstr[0] "Импортирован {0} снимок"
@@ -237,7 +224,6 @@ msgstr[1] "Импортированы {0} снимка"
 msgstr[2] "Импортировано {0} снимков"
 msgstr[3] "Импортировано {0} снимка"
 
-#. i18n: traffic sign
 msgid "Intersection danger"
 msgstr "Пересечение со второстепенной"
 
@@ -278,7 +264,6 @@ msgstr "Вход успешно выполнен, возврат в JOSM."
 msgid "Logout"
 msgstr "Выйти"
 
-#. i18n: traffic sign
 msgid "Mandatory direction (any)"
 msgstr "Предписываемое направление движения (любое)"
 
@@ -315,7 +300,6 @@ msgstr "Объекты Mapillary"
 msgid "Months"
 msgstr "месяцев"
 
-#, java-format
 msgid "Moved {0} image"
 msgid_plural "Moved {0} images"
 msgstr[0] "Перемещён {0} снимок"
@@ -326,25 +310,18 @@ msgstr[3] "Перемещено {0} снимка"
 msgid "Next picture"
 msgstr "Следующий снимок"
 
-#. i18n: traffic sign
 msgid "No entry"
 msgstr "Въезд запрещён"
-
-msgid "No image selected"
-msgstr "Изображение не выбрано"
 
 msgid "No images found"
 msgstr "Изображения не найдены"
 
-#. i18n: traffic sign
 msgid "No overtaking"
 msgstr "Обгон запрещён"
 
-#. i18n: traffic sign
 msgid "No parking"
 msgstr "Остановка запрещена"
 
-#. i18n: traffic sign
 msgid "No turn"
 msgstr "Поворот запрещён"
 
@@ -354,7 +331,6 @@ msgstr "Не выполнен вход в Mapillary"
 msgid "Not older than: "
 msgstr "Не старее: "
 
-#. i18n: Spinner label in JOSM settings
 msgid "Number of images to be pre-fetched (forwards and backwards)"
 msgstr "Количество снимков для упреждающей загрузки (вперёд и назад)"
 
@@ -382,18 +358,15 @@ msgstr "Пауза"
 msgid "Pauses the walk."
 msgstr "Приостановить прогулку"
 
-#. i18n: traffic sign
 msgid "Pedestrian crossing"
 msgstr "Пешеходный переход"
 
 msgid "Play"
 msgstr "Пуск"
 
-#, java-format
 msgid "Press \"{0}\" to download images"
 msgstr "Нажмите \"{0}\" для скачивания изображений"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Preview images when hovering its icon"
 msgstr "Предпросмотр изображения при наведении на его значок"
 
@@ -409,7 +382,6 @@ msgstr "Сброс"
 msgid "Rewrite imported images"
 msgstr "Перезаписать импортированные изображения"
 
-#. i18n: traffic sign
 msgid "Roundabout"
 msgstr "Круговое движение"
 
@@ -437,7 +409,6 @@ msgstr "Показать следующее изображение в после
 msgid "Shows the previous picture in the sequence"
 msgstr "Показать предыдущее изображение в последовательности"
 
-#. i18n: traffic sign
 msgid "Speed limit"
 msgstr "Ограничение скорости"
 
@@ -445,7 +416,6 @@ msgctxt "as synonym to halt or stand still"
 msgid "Stop"
 msgstr "Стоп"
 
-#. i18n: traffic sign
 msgctxt "name of the traffic sign"
 msgid "Stop"
 msgstr "Стоп"
@@ -459,7 +429,6 @@ msgstr "Передать пакет правок"
 msgid "Submit the current changeset"
 msgstr "Передать текущий пакет правок"
 
-#. CHECKSTYLE.OFF: LineLength
 msgid "Submit the current changeset to Mapillary"
 msgstr "Передать текущий  пакет правок в Mapillary"
 
@@ -494,7 +463,6 @@ msgstr ""
 msgid "There are currently no layers with geotagged images!"
 msgstr "Нет слоёв с геопривязанными изображениями!"
 
-#, java-format
 msgid ""
 "To solve this problem, you could switch to download mode ''{0}'' and load "
 "Mapillary images for a smaller portion of the map."
@@ -511,11 +479,9 @@ msgstr ""
 msgid "Too many map objects, zoom in to see all."
 msgstr "Слишком много объектов на карте. Приблизьте, чтобы увидеть все."
 
-#, java-format
 msgid "Total Mapillary images: {0}"
 msgstr "Всего снимков Mapillary: {0}"
 
-#, java-format
 msgid "Turned {0} image"
 msgid_plural "Turned {0} images"
 msgstr[0] "Повёрнут {0} снимок"
@@ -526,7 +492,6 @@ msgstr[3] "Повёрнуто {0} снимка"
 msgid "Undo"
 msgstr "Отменить"
 
-#. i18n: traffic sign
 msgid "Uneven road"
 msgstr "Неровная дорога"
 
@@ -539,11 +504,9 @@ msgstr "Отправить снимки Mapillary"
 msgid "Upload selected sequence"
 msgstr "Отправить выделенную последовательность"
 
-#, java-format
 msgid "Uploading: {0}"
 msgstr "Отправка: {0}"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Use 24 hour format"
 msgstr "Использовать 24-часовой формат"
 
@@ -564,7 +527,6 @@ msgstr ""
 "Режим прогулки: Ожидание следующего изображения занимает слишком много "
 "времени! Выход из режима прогулки…"
 
-#. i18n: Checkbox label in JOSM settings
 msgid ""
 "When opening Mapillary image in web browser, show the blur editor instead of"
 " the image viewer"
@@ -581,14 +543,19 @@ msgstr "лет"
 msgid "You are currently not logged in."
 msgstr "Вы не выполнили вход."
 
-#, java-format
 msgid "You are logged in as ''{0}''."
 msgstr "Вы вошли как ''{0}''."
 
 msgid "You are not logged in, please log in to Mapillary in the preferences"
 msgstr "Не выполнен вход, войдите в Mapillary в Настройках"
 
-#, java-format
+msgid ""
+"You are trying to upload a sequence to mapillary.com that you previously "
+"downloaded from there. That is not possible."
+msgstr ""
+"Вы пытаетесь загрузить на mapillary.com последовательность, которую вы ранее"
+" скачали оттуда. Это невозможно."
+
 msgid "You have successfully uploaded {0} image to mapillary.com"
 msgid_plural "You have successfully uploaded {0} images to mapillary.com"
 msgstr[0] "Вы успешно загрузили {0} изображение на mapillary.com"
@@ -605,18 +572,18 @@ msgstr "Приблизить вид до текущего выбранного �
 msgid "approved"
 msgstr "принят"
 
-#. i18n: download mode for Mapillary images
 msgid "areas with downloaded OSM-data"
 msgstr "области со скачанными данными OSM"
 
-#. i18n: download mode for Mapillary images
 msgid "everything in the visible area"
 msgstr "всё в видимой области"
 
 msgid "image has no key"
 msgstr "у снимка нет идентификатора"
 
-#. i18n: download mode for Mapillary images
+msgid "no image selected"
+msgstr "изображение не выбрано"
+
 msgid "only when manually requested"
 msgstr "только при запросе вручную"
 
@@ -632,7 +599,6 @@ msgstr "у последовательности нет идентификато�
 msgid "unknown user"
 msgstr "неизвестный пользователь"
 
-#, java-format
 msgid ""
 "{0}\n"
 "Could not read map objects from URL\n"
@@ -642,8 +608,6 @@ msgstr ""
 "Не удалось прочитать объекты карты из URL\n"
 "{1}!"
 
-#. i18n: {0} is the layer name, {1} the number of images in it
-#, java-format
 msgid "{0} ({1} image)"
 msgid_plural "{0} ({1} images)"
 msgstr[0] "{0} ({1} снимок)"
@@ -651,11 +615,9 @@ msgstr[1] "{0} ({1} снимка)"
 msgstr[2] "{0} ({1} снимков)"
 msgstr[3] "{0} ({1} снимков)"
 
-#, java-format
 msgid "{0} detections"
 msgstr "Обнаружено: {0}"
 
-#, java-format
 msgid "{0} downloaded image"
 msgid_plural "{0} downloaded images"
 msgstr[0] "{0} скачанный снимок"
@@ -663,7 +625,6 @@ msgstr[1] "{0} скачанных снимка"
 msgstr[2] "{0} скачанных снимков"
 msgstr[3] "{0} скачанных снимков"
 
-#, java-format
 msgid "{0} image in total"
 msgid_plural "{0} images in total"
 msgstr[0] "{0} снимок всего"
@@ -671,7 +632,6 @@ msgstr[1] "{0} снимка всего"
 msgstr[2] "{0} снимков всего"
 msgstr[3] "{0} снимков всего"
 
-#, java-format
 msgid "{0} image submitted, Changeset key: {1}, State: {2}"
 msgid_plural "{0} images submitted, Changeset key: {1}, State: {2}"
 msgstr[0] ""
@@ -683,11 +643,9 @@ msgstr[2] ""
 msgstr[3] ""
 "{0} снимков отправлено, идентификатор пакета правок: {1}, состояние: {2}"
 
-#, java-format
 msgid "{0} images in {1} sequences"
 msgstr "{0} снимков в {1} последовательностях"
 
-#, java-format
 msgid "{0} imported image"
 msgid_plural "{0} imported images"
 msgstr[0] "{0} импортированный снимок"
@@ -695,7 +653,6 @@ msgstr[1] "{0} импортированных снимка"
 msgstr[2] "{0} импортированных снимков"
 msgstr[3] "{0} импортированных снимков"
 
-#, java-format
 msgid "{0} sequence, containing between {1} and {2} images (ø {3})"
 msgid_plural ""
 "{0} sequences, each containing between {1} and {2} images (ø {3})"
@@ -707,7 +664,6 @@ msgstr[2] ""
 msgstr[3] ""
 "{0} последовательности, каждая содержит от {1} до {2} снимков (ø {3})"
 
-#. Plugin description for Mapillary
 msgid "Allows the user to work with pictures hosted at mapillary.com"
 msgstr ""
 "Позволяет пользователям работать с изображениями, размещёнными на "

--- a/src/main/po/sk.po
+++ b/src/main/po/sk.po
@@ -1,15 +1,15 @@
 # Translations for the JOSM plugin 'Mapillary' (sk)
-# Copyright (C) 2018 
+# Copyright (C) 2020
 # This file is distributed under the same license as the josm-plugin_Mapillary package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
-#, fuzzy
+#
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: josm-plugin_Mapillary v1.5.16-14-g82b2768\n"
+"Project-Id-Version: josm-plugin_Mapillary 1.5.20-3-ge40f8de\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-30 10:39+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"POT-Creation-Date: 2020-02-17 00:25+0000\n"
+"PO-Revision-Date: 2018-01-15 10:33+0000\n"
 "Language-Team: Slovak (https://www.transifex.com/josm/teams/2544/sk/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -23,7 +23,6 @@ msgstr "2 obrázky spojené"
 msgid "2 images unjoined"
 msgstr "2 obrázky rozpojené"
 
-#, java-format
 msgid ""
 "A tag with key <i>{0}</i> is already present on the selected OSM object."
 msgstr "Značka s kľúčom <i>{0}</i> už na zvolenom OSM objekte existuje."
@@ -51,7 +50,6 @@ msgstr ""
 msgid "Cancel"
 msgstr "Zrušiť"
 
-#, java-format
 msgid "Changeset upload failed with {0} error ''{1} {2}''!"
 msgstr "Odoslanie sady zmien zlyhalo s {0} chybou \"{1} {2}\"!"
 
@@ -68,26 +66,21 @@ msgid "Could not import a geotagged image to the Mapillary layer!"
 msgstr ""
 "Nepodarilo sa importovať obrázok s geografickou polohou do vrstvy Mapillary!"
 
-#, java-format
 msgid "Could not import the directory ''{0}''!"
 msgstr "Nepodarilo sa importovať priečinok \"{0}\"!"
 
-#, java-format
 msgid "Could not import the image ''{0}''!"
 msgstr "Nepodarilo sa importovať obrázok \"{0}\"!"
 
-#, java-format
 msgid "Could not open the URL {0} in a browser"
 msgstr "Nepodarilo sa otvoriť adresu {0} v prehliadači"
 
-#, java-format
 msgid "Could not read from URL {0}!"
 msgstr "Nepodarilo sa čítať z adresy {0}!"
 
 msgid "Current Mapillary changeset"
 msgstr "Aktuálna sada zmien Mapillary"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Cut off sequences at download bounds"
 msgstr "Odseknúť postupnosť na hranici stiahnutej oblasti"
 
@@ -97,15 +90,13 @@ msgstr "Dní"
 msgid "Delete after upload"
 msgstr "Vymazať po odoslaní"
 
-#, java-format
 msgid "Deleted {0} image"
 msgid_plural "Deleted {0} images"
-msgstr[0] "{0} obrázkov vymazaných"
-msgstr[1] "{0} obrázok vymazaný"
-msgstr[2] "{0} obrázky vymazané"
-msgstr[3] "{0} obrázky vymazané"
+msgstr[0] "{0} obrázok vymazaný"
+msgstr[1] "{0} obrázky vymazané"
+msgstr[2] "{0} obrázkov vymazaných"
+msgstr[3] "{0} obrázkov vymazaných"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Display hour when the picture was taken"
 msgstr "Zobraziť hodinu kedy bol obrázok zaznamenaný"
 
@@ -118,7 +109,6 @@ msgstr "Zobrazí objekty detegované Mapillary z obrázkov ulíc"
 msgid "Displays the layer displaying the map objects detected by Mapillary"
 msgstr "Zobrazí vrstvu s mapovými objektami, ktoré identifikoval Mapillary"
 
-#, java-format
 msgid ""
 "Do you really want to replace the current value <i>{0}</i> with the new "
 "value <i>{1}</i>?"
@@ -144,7 +134,6 @@ msgstr "Sťahovanie mapových objektov zlyhalo!"
 msgid "Downloading map objects…"
 msgstr "Sťahujú sa mapové objekty…"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Enable experimental beta-features (might be unstable)"
 msgstr "Zapnúť experimentálne vyvíjané funkcie (môžu byť nestabilné)"
 
@@ -172,7 +161,6 @@ msgstr "Z existujúcej vrstvy obrázkov"
 msgid "From which source do you want to import images to the Mapillary layer?"
 msgstr "Z akého zdroja chcete importovať obrázky do vrstvy Mapillary?"
 
-#. i18n: traffic sign
 msgid "Give way"
 msgstr "Daj prednosť v jazde"
 
@@ -218,15 +206,13 @@ msgstr "Importovať obrázky do vrstvy Mapillary"
 msgid "Imported images"
 msgstr "Importované obrázky"
 
-#, java-format
 msgid "Imported {0} image"
 msgid_plural "Imported {0} images"
-msgstr[0] "{0} obrázkov importovaných"
-msgstr[1] "{0} obrázok importovaný"
-msgstr[2] "{0} obrázky importované"
-msgstr[3] "{0} obrázky importované"
+msgstr[0] "{0} obrázok importovaný"
+msgstr[1] "{0} obrázky importované"
+msgstr[2] "{0} obrázkov importovaných"
+msgstr[3] "{0} obrázkov importovaných"
 
-#. i18n: traffic sign
 msgid "Intersection danger"
 msgstr "Pozor, križovatka"
 
@@ -264,7 +250,6 @@ msgstr "Prihlásenie úspešné, vráťte sa do JOSM."
 msgid "Logout"
 msgstr "Odhlásiť sa"
 
-#. i18n: traffic sign
 msgid "Mandatory direction (any)"
 msgstr "Prikázaný smer jazdy"
 
@@ -298,43 +283,34 @@ msgstr "Objekty Mapillary"
 msgid "Months"
 msgstr "Mesiacov"
 
-#, java-format
 msgid "Moved {0} image"
 msgid_plural "Moved {0} images"
-msgstr[0] "{0} obrázkov presunutých"
-msgstr[1] "{0} obrázok presunutý"
-msgstr[2] "{0} obrázky presunuté"
-msgstr[3] "{0} obrázky presunuté"
+msgstr[0] "{0} obrázok presunutý"
+msgstr[1] "{0} obrázky presunuté"
+msgstr[2] "{0} obrázkov presunutých"
+msgstr[3] "{0} obrázkov presunutých"
 
 msgid "Next picture"
 msgstr "Nasledujúci obrázok"
 
-#. i18n: traffic sign
 msgid "No entry"
 msgstr "Zákaz vstupu"
-
-msgid "No image selected"
-msgstr "Nie je vybratý žiadny obrázok"
 
 msgid "No images found"
 msgstr "Nenašli sa žiadne obrázky"
 
-#. i18n: traffic sign
 msgid "No overtaking"
 msgstr "Zákaz predbiehania"
 
-#. i18n: traffic sign
 msgid "No parking"
 msgstr "Zákaz parkovania"
 
-#. i18n: traffic sign
 msgid "No turn"
 msgstr "Zákaz odbočenia"
 
 msgid "Not older than: "
 msgstr "Nie staršie ako: "
 
-#. i18n: Spinner label in JOSM settings
 msgid "Number of images to be pre-fetched (forwards and backwards)"
 msgstr "Počet obrázkov načítaných vopred (dopredu a dozadu)"
 
@@ -362,18 +338,15 @@ msgstr "Pozastaviť"
 msgid "Pauses the walk."
 msgstr "Pozastaví chôdzu."
 
-#. i18n: traffic sign
 msgid "Pedestrian crossing"
 msgstr "Priechod pre chodcov"
 
 msgid "Play"
 msgstr "Prehrať"
 
-#, java-format
 msgid "Press \"{0}\" to download images"
 msgstr "Stlačte \"{0}\" pre stiahnutie obrázkov"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Preview images when hovering its icon"
 msgstr "Zobraziť náhľady obrázkov pri prejdení nad ich ikonou"
 
@@ -389,7 +362,6 @@ msgstr "Vynulovať (Reset)"
 msgid "Rewrite imported images"
 msgstr "Prepísať importované obrázky"
 
-#. i18n: traffic sign
 msgid "Roundabout"
 msgstr "Kruhový objazd"
 
@@ -417,7 +389,6 @@ msgstr "Zobrazí nasledujúci obrázok v postupnosti"
 msgid "Shows the previous picture in the sequence"
 msgstr "Zobrazí predchádzajúci obrázok v postupnosti"
 
-#. i18n: traffic sign
 msgid "Speed limit"
 msgstr "Rýchlostné obmedzenie"
 
@@ -425,7 +396,6 @@ msgctxt "as synonym to halt or stand still"
 msgid "Stop"
 msgstr "Značka \"Zastaviť (stop)\""
 
-#. i18n: traffic sign
 msgctxt "name of the traffic sign"
 msgid "Stop"
 msgstr "Značka \"Zastaviť (stop)\""
@@ -439,7 +409,6 @@ msgstr "Odoslať sadu zmien"
 msgid "Submit the current changeset"
 msgstr "Odoslať aktuálnu sadu zmien"
 
-#. CHECKSTYLE.OFF: LineLength
 msgid "Submit the current changeset to Mapillary"
 msgstr "Odoslať aktuálnu sadu zmien do Mapillary"
 
@@ -474,7 +443,6 @@ msgstr ""
 msgid "There are currently no layers with geotagged images!"
 msgstr "Nemáte žiadne vrstvy s obrázkami s geografickou polohou!"
 
-#, java-format
 msgid ""
 "To solve this problem, you could switch to download mode ''{0}'' and load "
 "Mapillary images for a smaller portion of the map."
@@ -492,22 +460,19 @@ msgid "Too many map objects, zoom in to see all."
 msgstr ""
 "Príliš veľa mapových objektov. Priblížte oblasť, aby ste videli všetky."
 
-#, java-format
 msgid "Total Mapillary images: {0}"
 msgstr "Spolu obrázkov Mapillary: {0}"
 
-#, java-format
 msgid "Turned {0} image"
 msgid_plural "Turned {0} images"
-msgstr[0] "{0} obrázkov otočených"
-msgstr[1] "{0} obrázok otočený"
-msgstr[2] "{0} obrázky otočené"
-msgstr[3] "{0} obrázky otočené"
+msgstr[0] "{0} obrázok otočený"
+msgstr[1] "{0} obrázky otočené"
+msgstr[2] "{0} obrázkov otočených"
+msgstr[3] "{0} obrázkov otočených"
 
 msgid "Undo"
 msgstr "Späť"
 
-#. i18n: traffic sign
 msgid "Uneven road"
 msgstr "Nerovná cesta"
 
@@ -520,11 +485,9 @@ msgstr "Odoslať obrázky Mapillary"
 msgid "Upload selected sequence"
 msgstr "Odoslať vybranú postupnosť"
 
-#, java-format
 msgid "Uploading: {0}"
 msgstr "Odosiela sa: {0}"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Use 24 hour format"
 msgstr "Použiť 24-hodinový formát"
 
@@ -540,7 +503,6 @@ msgstr "Čakať na obrázky v plnej kvalite"
 msgid "Walk mode"
 msgstr "Režim chôdze"
 
-#. i18n: Checkbox label in JOSM settings
 msgid ""
 "When opening Mapillary image in web browser, show the blur editor instead of"
 " the image viewer"
@@ -557,7 +519,6 @@ msgstr "Rokov"
 msgid "You are currently not logged in."
 msgstr "Nie ste prihlásený."
 
-#, java-format
 msgid "You are logged in as ''{0}''."
 msgstr "Ste prihlásený ako \"{0}\"."
 
@@ -573,18 +534,15 @@ msgstr "Priblížiť na zvolený obrázok z Mapillary"
 msgid "approved"
 msgstr "schválená"
 
-#. i18n: download mode for Mapillary images
 msgid "areas with downloaded OSM-data"
 msgstr "oblasti s už stiahnutými údajmi OSM"
 
-#. i18n: download mode for Mapillary images
 msgid "everything in the visible area"
 msgstr "všetko vo viditeľnej oblasti"
 
 msgid "image has no key"
 msgstr "obrázok nemá kľúč"
 
-#. i18n: download mode for Mapillary images
 msgid "only when manually requested"
 msgstr "len keď je požadované"
 
@@ -600,7 +558,6 @@ msgstr "postupnosť nemá kľúč"
 msgid "unknown user"
 msgstr "neznámy používateľ"
 
-#, java-format
 msgid ""
 "{0}\n"
 "Could not read map objects from URL\n"
@@ -610,14 +567,11 @@ msgstr ""
 "Nepodarilo sa čítať mapové objekty z adresy\n"
 "{1}!"
 
-#, java-format
 msgid "{0} detections"
 msgstr "{0} detekovaných objektov"
 
-#, java-format
 msgid "{0} images in {1} sequences"
 msgstr "{0} obrázkov v {1} postupnostiach"
 
-#. Plugin description for Mapillary
 msgid "Allows the user to work with pictures hosted at mapillary.com"
 msgstr "Umožňuje používateľovi pracovať s obrázkami na mapillary.com"

--- a/src/main/po/sv.po
+++ b/src/main/po/sv.po
@@ -1,15 +1,15 @@
 # Translations for the JOSM plugin 'Mapillary' (sv)
-# Copyright (C) 2018 
+# Copyright (C) 2020
 # This file is distributed under the same license as the josm-plugin_Mapillary package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
-#, fuzzy
+#
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: josm-plugin_Mapillary v1.5.16-14-g82b2768\n"
+"Project-Id-Version: josm-plugin_Mapillary 1.5.20-3-ge40f8de\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-30 10:39+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"POT-Creation-Date: 2020-02-17 00:25+0000\n"
+"PO-Revision-Date: 2018-01-15 10:33+0000\n"
 "Language-Team: Swedish (https://www.transifex.com/josm/teams/2544/sv/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -23,7 +23,6 @@ msgstr "2 bilder kopplade"
 msgid "2 images unjoined"
 msgstr "2 bilder särkopplade"
 
-#, java-format
 msgid ""
 "A tag with key <i>{0}</i> is already present on the selected OSM object."
 msgstr "En tagg med nyckel <i>{0}</i> finns redan på markerat OSM-objekt."
@@ -60,19 +59,15 @@ msgstr "Kopiera nyckel"
 msgid "Could not import a geotagged image to the Mapillary layer!"
 msgstr "Kunde inte importera en geotaggad bild in i Mapillary-lagret!"
 
-#, java-format
 msgid "Could not import the directory ''{0}''!"
 msgstr "Kunde inte importera mappen \"{0}\"!"
 
-#, java-format
 msgid "Could not import the image ''{0}''!"
 msgstr "Kunde inte importera bilden \"{0}\"!"
 
-#, java-format
 msgid "Could not open the URL {0} in a browser"
 msgstr "Kunde inte öppna länken {0} i en webbläsare"
 
-#, java-format
 msgid "Could not read from URL {0}!"
 msgstr "Kunde inte läsa länken {0}!"
 
@@ -85,13 +80,11 @@ msgstr "Dagar"
 msgid "Delete after upload"
 msgstr "Ta bort efter uppladdning"
 
-#, java-format
 msgid "Deleted {0} image"
 msgid_plural "Deleted {0} images"
 msgstr[0] "Tog bort en bild"
 msgstr[1] "Tog bort {0} bilder"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Display hour when the picture was taken"
 msgstr "Visa vilken timme bilden var tagen på"
 
@@ -104,7 +97,6 @@ msgstr "Visar objekt som Mapillary upptäckte i deras gatuvybilder"
 msgid "Displays the layer displaying the map objects detected by Mapillary"
 msgstr "Visar lagret som visar kartobjekten som upptäckts av Mapillary"
 
-#, java-format
 msgid ""
 "Do you really want to replace the current value <i>{0}</i> with the new "
 "value <i>{1}</i>?"
@@ -131,7 +123,6 @@ msgstr "Laddar ner kartobjekt..."
 msgid "Downloading…"
 msgstr "Laddar ner..."
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Enable experimental beta-features (might be unstable)"
 msgstr "Slå på experimentella beta-funktioner (de kan vara instabila)"
 
@@ -165,7 +156,6 @@ msgstr "Från existerande bildlager"
 msgid "From which source do you want to import images to the Mapillary layer?"
 msgstr "Från vilken källa vill du importera bilder till Mapillarylagret?"
 
-#. i18n: traffic sign
 msgid "Give way"
 msgstr "Väjningsplikt"
 
@@ -204,7 +194,6 @@ msgstr "Importera bilder till Mapillary-lager"
 msgid "Imported images"
 msgstr "Importerade bilder"
 
-#, java-format
 msgid "Imported {0} image"
 msgid_plural "Imported {0} images"
 msgstr[0] "Importerade en bild"
@@ -265,7 +254,6 @@ msgstr "Mapillaryobjekt"
 msgid "Months"
 msgstr "Månader"
 
-#, java-format
 msgid "Moved {0} image"
 msgid_plural "Moved {0} images"
 msgstr[0] "Flyttade en bild"
@@ -274,24 +262,18 @@ msgstr[1] "Flyttade {0} bilder"
 msgid "Next picture"
 msgstr "Nästa bild"
 
-msgid "No image selected"
-msgstr "Ingen bild är vald"
-
 msgid "No images found"
 msgstr "Ingen bild funnen"
 
-#. i18n: traffic sign
 msgid "No overtaking"
 msgstr "Omkörningsförbud"
 
-#. i18n: traffic sign
 msgid "No parking"
 msgstr "Parkeringsförbud"
 
 msgid "Not older than: "
 msgstr "Inte äldre än:"
 
-#. i18n: Spinner label in JOSM settings
 msgid "Number of images to be pre-fetched (forwards and backwards)"
 msgstr "Antal bilder som kommer bli hämtade i förhand (frammåt och bakåt)"
 
@@ -304,15 +286,12 @@ msgstr "Öppna dialogrutan för Mapillaryändringsset"
 msgid "Pause"
 msgstr "Pausa"
 
-#. i18n: traffic sign
 msgid "Pedestrian crossing"
 msgstr "Övergångsställe"
 
-#, java-format
 msgid "Press \"{0}\" to download images"
 msgstr "Tryck på \"{0}\" för att ladda ner bilder"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Preview images when hovering its icon"
 msgstr "Förhandsgranska bilder genom att hovrar över dess ikon"
 
@@ -325,7 +304,6 @@ msgstr "Återställ"
 msgid "Reset"
 msgstr "Återställ"
 
-#. i18n: traffic sign
 msgid "Roundabout"
 msgstr "Cirkulationsplats"
 
@@ -350,7 +328,6 @@ msgstr "Visar nästa bild i sekvensen"
 msgid "Shows the previous picture in the sequence"
 msgstr "Visar föregående bild i sekvensen"
 
-#. i18n: traffic sign
 msgid "Speed limit"
 msgstr "Hastighetsbegränsning"
 
@@ -358,7 +335,6 @@ msgctxt "as synonym to halt or stand still"
 msgid "Stop"
 msgstr "Stopp"
 
-#. i18n: traffic sign
 msgctxt "name of the traffic sign"
 msgid "Stop"
 msgstr "Stopp"
@@ -379,7 +355,6 @@ msgstr ""
 msgid "There are currently no layers with geotagged images!"
 msgstr "Det finns för tillfället inga lager med geotaggade bilder!"
 
-#, java-format
 msgid ""
 "To solve this problem, you could switch to download mode ''{0}'' and load "
 "Mapillary images for a smaller portion of the map."
@@ -396,14 +371,12 @@ msgstr ""
 msgid "Too many map objects, zoom in to see all."
 msgstr "För många kartobjekt, zooma in för att se alla."
 
-#, java-format
 msgid "Total Mapillary images: {0}"
 msgstr "Toalt antal Mapillarybilder: {0}"
 
 msgid "Undo"
 msgstr "Ångra"
 
-#. i18n: traffic sign
 msgid "Uneven road"
 msgstr "Ojämn väg"
 
@@ -413,11 +386,9 @@ msgstr "Uppdatera"
 msgid "Upload Mapillary images"
 msgstr "Ladda upp Mapillarybilder"
 
-#, java-format
 msgid "Uploading: {0}"
 msgstr "Laddar upp: {0}"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Use 24 hour format"
 msgstr "Använd 24-timmarsformat"
 
@@ -436,7 +407,6 @@ msgstr "År"
 msgid "You are currently not logged in."
 msgstr "Du är för nuvarande inte inloggad."
 
-#, java-format
 msgid "You are logged in as ''{0}''."
 msgstr "Du är inloggad som \"{0}\"."
 
@@ -453,11 +423,9 @@ msgstr "Zooma till den för valda Mapillarybilden"
 msgid "approved"
 msgstr "godkänd"
 
-#. i18n: download mode for Mapillary images
 msgid "areas with downloaded OSM-data"
 msgstr "ytor med nedladdad OSM-data"
 
-#. i18n: download mode for Mapillary images
 msgid "everything in the visible area"
 msgstr "allt inom det synliga området"
 
@@ -470,7 +438,6 @@ msgstr "avvisad"
 msgid "unknown user"
 msgstr "okänd användare"
 
-#, java-format
 msgid ""
 "{0}\n"
 "Could not read map objects from URL\n"
@@ -480,6 +447,5 @@ msgstr ""
 "Kunde inte läsa kartobjekt från URL\n"
 "{1}!"
 
-#. Plugin description for Mapillary
 msgid "Allows the user to work with pictures hosted at mapillary.com"
 msgstr "Tillåter användaren att arbeta med bilder på mapillary.com"

--- a/src/main/po/uk.po
+++ b/src/main/po/uk.po
@@ -1,15 +1,15 @@
 # Translations for the JOSM plugin 'Mapillary' (uk)
-# Copyright (C) 2018 
+# Copyright (C) 2020
 # This file is distributed under the same license as the josm-plugin_Mapillary package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
-#, fuzzy
+#
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: josm-plugin_Mapillary v1.5.16-14-g82b2768\n"
+"Project-Id-Version: josm-plugin_Mapillary 1.5.20-3-ge40f8de\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-30 10:39+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"POT-Creation-Date: 2020-02-17 00:25+0000\n"
+"PO-Revision-Date: 2018-01-15 10:33+0000\n"
 "Language-Team: Ukrainian (https://www.transifex.com/josm/teams/2544/uk/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -23,7 +23,6 @@ msgstr "2 зображення з’єднано"
 msgid "2 images unjoined"
 msgstr "2 зображення роз’єднано"
 
-#, java-format
 msgid ""
 "A tag with key <i>{0}</i> is already present on the selected OSM object."
 msgstr "Теґ з ключем <i>{0}</i> вже присутній у виділеного обʼєкта OSM."
@@ -51,7 +50,12 @@ msgstr ""
 msgid "Cancel"
 msgstr "Скасувати"
 
-#, java-format
+msgid ""
+"Center view on new image when using the buttons to jump to another image"
+msgstr ""
+"Перегляд у центрі на новому зображенні застосовуйте клавіші для переходу до "
+"іншого зображення"
+
 msgid "Changeset upload failed with {0} error ''{1} {2}''!"
 msgstr "Невдалось надісати набір змін, помилка  {0} ''{1} {2}''!"
 
@@ -67,28 +71,26 @@ msgstr "Копіювати ключ"
 msgid "Could not import a geotagged image to the Mapillary layer!"
 msgstr "Неможливо імпортувати геотеговані знімки до шару Mapillary’!"
 
-#, java-format
 msgid "Could not import the directory ''{0}''!"
 msgstr "Неможливо імпортувати теку ''{0}''!"
 
-#, java-format
 msgid "Could not import the image ''{0}''!"
 msgstr "Неможливо імпортувати зображення ''{0}''!"
 
-#, java-format
 msgid "Could not open the URL {0} in a browser"
 msgstr "Не можливо відкрити URL {0} в оглядачі"
 
-#, java-format
 msgid "Could not read from URL {0}!"
 msgstr "Неможливо зчитати за посиланням URL {0}!"
 
 msgid "Current Mapillary changeset"
 msgstr "Поточний набір змін Mapillary"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Cut off sequences at download bounds"
 msgstr "Обмежити послідовність межами завантаженої ділянки"
+
+msgid "Dark mode for image display"
+msgstr "Нічний режим показу зображень"
 
 msgid "Days"
 msgstr "Дні"
@@ -96,7 +98,6 @@ msgstr "Дні"
 msgid "Delete after upload"
 msgstr "Вилучити післа надсиланання"
 
-#, java-format
 msgid "Deleted {0} image"
 msgid_plural "Deleted {0} images"
 msgstr[0] "Вилучений {0} знімок"
@@ -104,7 +105,6 @@ msgstr[1] "Вилучено {0} знімки"
 msgstr[2] "Вилучено {0} знімків"
 msgstr[3] "Вилучено {0} знімків"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Display hour when the picture was taken"
 msgstr "Показувати час, коли було зроблено знімок"
 
@@ -117,7 +117,6 @@ msgstr "Показує обʼєкти, які були виявлені Mapillar
 msgid "Displays the layer displaying the map objects detected by Mapillary"
 msgstr "Показує шар з обʼєктами, що були виявлені Mapillary"
 
-#, java-format
 msgid ""
 "Do you really want to replace the current value <i>{0}</i> with the new "
 "value <i>{1}</i>?"
@@ -145,12 +144,14 @@ msgstr "Завантаження обʼєктів мапи…"
 msgid "Downloading…"
 msgstr "Завантаження…"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Enable experimental beta-features (might be unstable)"
 msgstr "Увімкнути експериментальні бета-функції (можуть бути нестабільними)"
 
 msgid "Explore"
 msgstr "Оглянути"
+
+msgid "Export Mapillary images"
+msgstr "Експорт зображень Mapillary"
 
 msgid "Export all images"
 msgstr "Експортувати всі знімки"
@@ -160,6 +161,9 @@ msgstr "Експортувати виділені знімки"
 
 msgid "Export selected sequence"
 msgstr "Експортувати обрану послідовність"
+
+msgid "Exporting Mapillary Images…"
+msgstr "Експортування зображень Mapillary..."
 
 msgid "Finished upload"
 msgstr "Надсилання закінчене"
@@ -173,7 +177,6 @@ msgstr "З поточного шару зображень"
 msgid "From which source do you want to import images to the Mapillary layer?"
 msgstr "З яких джерел ви бажаєте імпортувати зображення до шару Mapillary?"
 
-#. i18n: traffic sign
 msgid "Give way"
 msgstr "Дати дорогу"
 
@@ -220,7 +223,6 @@ msgstr "Імпортувати знімки до шару Mapillary"
 msgid "Imported images"
 msgstr "Імпортовані знімки"
 
-#, java-format
 msgid "Imported {0} image"
 msgid_plural "Imported {0} images"
 msgstr[0] "Імпортований {0} знімок"
@@ -228,7 +230,6 @@ msgstr[1] "Імпортовано {0} знімки"
 msgstr[2] "Імпортовано {0} знімків"
 msgstr[3] "Імпортовано {0} знімків"
 
-#. i18n: traffic sign
 msgid "Intersection danger"
 msgstr "Перехрещення з другорядною дорогою"
 
@@ -257,6 +258,9 @@ msgstr "Перейти до зображення з іншого боку від
 msgid "Jumps to the picture at the other side of the red line"
 msgstr "Перейти до знімку з іншого боку від червоної лінії"
 
+msgid "Key copied to clipboard…"
+msgstr "Ключ скопійовано до буферу обміну..."
+
 msgid "Login"
 msgstr "Увійти"
 
@@ -266,7 +270,6 @@ msgstr "Вдалий вхід, повертаємось в JOSM."
 msgid "Logout"
 msgstr "Вихід"
 
-#. i18n: traffic sign
 msgid "Mandatory direction (any)"
 msgstr "Напрямок руху"
 
@@ -285,6 +288,9 @@ msgstr "Фільтр Mapillary"
 msgid "Mapillary history"
 msgstr "Історія Mapillary"
 
+msgid "Mapillary image"
+msgstr "Зображення Mapillary"
+
 msgid "Mapillary layer"
 msgstr "Mapillary"
 
@@ -300,7 +306,6 @@ msgstr "Обʼєкти Mapillary"
 msgid "Months"
 msgstr "Місяці"
 
-#, java-format
 msgid "Moved {0} image"
 msgid_plural "Moved {0} images"
 msgstr[0] "Переміщено {0} зображення"
@@ -311,32 +316,27 @@ msgstr[3] "Переміщено {0} зображень"
 msgid "Next picture"
 msgstr "Наступний знімок"
 
-#. i18n: traffic sign
 msgid "No entry"
 msgstr "В’їзд заборонено"
-
-msgid "No image selected"
-msgstr "Не обрано жодного зображення"
 
 msgid "No images found"
 msgstr "Знімків не знайдено"
 
-#. i18n: traffic sign
 msgid "No overtaking"
 msgstr "Обгін заборонений"
 
-#. i18n: traffic sign
 msgid "No parking"
 msgstr "Стоянка заборонена"
 
-#. i18n: traffic sign
 msgid "No turn"
 msgstr "Поворот заборонений"
+
+msgid "Not logged in to Mapillary"
+msgstr "Не залоґінився до Mapillary"
 
 msgid "Not older than: "
 msgstr "Не старіше ніж: "
 
-#. i18n: Spinner label in JOSM settings
 msgid "Number of images to be pre-fetched (forwards and backwards)"
 msgstr "Кількість знімків для попереднього завантаження (вперед та назад)"
 
@@ -364,18 +364,15 @@ msgstr "Пауза"
 msgid "Pauses the walk."
 msgstr "Призупиняє перегляд"
 
-#. i18n: traffic sign
 msgid "Pedestrian crossing"
 msgstr "Пішохідний перехід"
 
 msgid "Play"
 msgstr "Пуск"
 
-#, java-format
 msgid "Press \"{0}\" to download images"
 msgstr "Натисніть \"{0}\" для завантаження зображень"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Preview images when hovering its icon"
 msgstr "Попередній перегляд зображень при наведенні курсору на їх значок"
 
@@ -391,7 +388,6 @@ msgstr "Скинути"
 msgid "Rewrite imported images"
 msgstr "Перезаписати імпортовані зображення"
 
-#. i18n: traffic sign
 msgid "Roundabout"
 msgstr "Круг"
 
@@ -419,7 +415,6 @@ msgstr "Показує наступний знімок послідовност�
 msgid "Shows the previous picture in the sequence"
 msgstr "Показує попередній знімок послідовності"
 
-#. i18n: traffic sign
 msgid "Speed limit"
 msgstr "Обмеження швидкості"
 
@@ -427,7 +422,6 @@ msgctxt "as synonym to halt or stand still"
 msgid "Stop"
 msgstr "Стоп"
 
-#. i18n: traffic sign
 msgctxt "name of the traffic sign"
 msgid "Stop"
 msgstr "Стоп"
@@ -441,7 +435,6 @@ msgstr "Надіслати набір змін"
 msgid "Submit the current changeset"
 msgstr "Надіслати поточний набір змін"
 
-#. CHECKSTYLE.OFF: LineLength
 msgid "Submit the current changeset to Mapillary"
 msgstr "Надіслати поточний набір змін до Mapillary"
 
@@ -476,7 +469,6 @@ msgstr ""
 msgid "There are currently no layers with geotagged images!"
 msgstr "Шар зображень з геопривʼязкою відсутній!"
 
-#, java-format
 msgid ""
 "To solve this problem, you could switch to download mode ''{0}'' and load "
 "Mapillary images for a smaller portion of the map."
@@ -493,11 +485,9 @@ msgstr ""
 msgid "Too many map objects, zoom in to see all."
 msgstr "Забагато обʼєктів, треба наблизитись, щоб побачити їх всі."
 
-#, java-format
 msgid "Total Mapillary images: {0}"
 msgstr "Всього знімків Mapillary: {0}"
 
-#, java-format
 msgid "Turned {0} image"
 msgid_plural "Turned {0} images"
 msgstr[0] "Обернуто {0} зображення"
@@ -508,7 +498,6 @@ msgstr[3] "Обернуто {0} зображень"
 msgid "Undo"
 msgstr "Скасувати"
 
-#. i18n: traffic sign
 msgid "Uneven road"
 msgstr "Нерівна дорога"
 
@@ -521,11 +510,9 @@ msgstr "Надіслати знімки Mapillary"
 msgid "Upload selected sequence"
 msgstr "Надіслати виділену послідовність"
 
-#, java-format
 msgid "Uploading: {0}"
 msgstr "Надсилання: {0}"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Use 24 hour format"
 msgstr "Використовувати 24-годинний формат"
 
@@ -541,7 +528,11 @@ msgstr "Чекати якісних фотографій"
 msgid "Walk mode"
 msgstr "Пішохідний режим"
 
-#. i18n: Checkbox label in JOSM settings
+msgid "Walk mode: Waiting for next image takes too long! Exiting walk mode…"
+msgstr ""
+"Режим ходьби: очікування наступного зображення триває довго! Вихід із режиму"
+" ходьби…"
+
 msgid ""
 "When opening Mapillary image in web browser, show the blur editor instead of"
 " the image viewer"
@@ -558,12 +549,18 @@ msgstr "Роки"
 msgid "You are currently not logged in."
 msgstr "Ви ще не ввійшли."
 
-#, java-format
 msgid "You are logged in as ''{0}''."
 msgstr "Ви увійшли як  ''{0}''."
 
 msgid "You are not logged in, please log in to Mapillary in the preferences"
 msgstr "Ви не увійшли, будь ласка, здійсніть вхід в налаштуваннях  Mapillary"
+
+msgid ""
+"You are trying to upload a sequence to mapillary.com that you previously "
+"downloaded from there. That is not possible."
+msgstr ""
+"Ви намагаєтеся завантажити послідовність до mapillary.com, яку ви раніше "
+"скачали звідти. Це неможливо."
 
 msgid "Zoom to selected image"
 msgstr "Масштабувати до виділеного знімка"
@@ -574,18 +571,18 @@ msgstr "Масштабувати до поточного виділеного з
 msgid "approved"
 msgstr "затверджено"
 
-#. i18n: download mode for Mapillary images
 msgid "areas with downloaded OSM-data"
 msgstr "області із завантаженими даними OSM"
 
-#. i18n: download mode for Mapillary images
 msgid "everything in the visible area"
 msgstr "все, що є у видимій області"
 
 msgid "image has no key"
 msgstr "знімок не має ключа"
 
-#. i18n: download mode for Mapillary images
+msgid "no image selected"
+msgstr "не обрано зображень"
+
 msgid "only when manually requested"
 msgstr "тільки під час отримання запиту вручну"
 
@@ -601,7 +598,6 @@ msgstr "послідовність не має ключа"
 msgid "unknown user"
 msgstr "невідомий користувач"
 
-#, java-format
 msgid ""
 "{0}\n"
 "Could not read map objects from URL\n"
@@ -611,14 +607,11 @@ msgstr ""
 "Не вийшло отримати обʼєкти мапи за посиланням URL\n"
 "{1}!"
 
-#, java-format
 msgid "{0} detections"
 msgstr "{0} образів"
 
-#, java-format
 msgid "{0} images in {1} sequences"
 msgstr "{0} знімків в {1} послідовностях"
 
-#. Plugin description for Mapillary
 msgid "Allows the user to work with pictures hosted at mapillary.com"
 msgstr "Дозволяє користувачам використовувати знімки з mapillary.com"

--- a/src/main/po/zh_CN.po
+++ b/src/main/po/zh_CN.po
@@ -1,15 +1,15 @@
 # Translations for the JOSM plugin 'Mapillary' (zh_CN)
-# Copyright (C) 2018 
+# Copyright (C) 2020
 # This file is distributed under the same license as the josm-plugin_Mapillary package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
-#, fuzzy
+#
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: josm-plugin_Mapillary v1.5.16-14-g82b2768\n"
+"Project-Id-Version: josm-plugin_Mapillary 1.5.20-3-ge40f8de\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-30 10:39+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"POT-Creation-Date: 2020-02-17 00:25+0000\n"
+"PO-Revision-Date: 2018-01-15 10:33+0000\n"
 "Language-Team: Chinese (China) (https://www.transifex.com/josm/teams/2544/zh_CN/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -23,7 +23,6 @@ msgstr "加入了2张图片"
 msgid "2 images unjoined"
 msgstr "2张图片未加入"
 
-#, java-format
 msgid ""
 "A tag with key <i>{0}</i> is already present on the selected OSM object."
 msgstr "包含键 <i>{0}</i> 的标签已在所选OSM对象上出现。"
@@ -33,6 +32,9 @@ msgstr "添加Mapillary标签"
 
 msgid "All images in a directory"
 msgstr "在某一目录下的所有图像"
+
+msgid "All map objects loaded."
+msgstr "所有地图对象已加载。"
 
 msgid ""
 "An exception occured while trying to submit a changeset. If this happens "
@@ -44,7 +46,10 @@ msgstr "在试图提交修改集合时发生意外。若反复出现，考虑通
 msgid "Cancel"
 msgstr "取消"
 
-#, java-format
+msgid ""
+"Center view on new image when using the buttons to jump to another image"
+msgstr "跳转至新图像时使图像居中"
+
 msgid "Changeset upload failed with {0} error ''{1} {2}''!"
 msgstr "修改集合上传失败由于{0}错误 ''{1} {2}''!"
 
@@ -54,19 +59,29 @@ msgstr "选择标志"
 msgid "Continues with the paused walk."
 msgstr "继续已暂停的步行"
 
+msgid "Copy key"
+msgstr "复制键值"
+
 msgid "Could not import a geotagged image to the Mapillary layer!"
 msgstr "无法将地理标签图像导入Mapillary层！"
 
-#, java-format
 msgid "Could not import the directory ''{0}''!"
 msgstr "无法导入目录''{0}''！"
 
-#, java-format
 msgid "Could not import the image ''{0}''!"
 msgstr "无法导入图像''{0}''！"
 
+msgid "Could not open the URL {0} in a browser"
+msgstr "无法在浏览器中打开 URL {0}"
+
+msgid "Could not read from URL {0}!"
+msgstr "无法读取 URL {0}！"
+
 msgid "Current Mapillary changeset"
 msgstr "当前Mapillary修改集合"
+
+msgid "Cut off sequences at download bounds"
+msgstr "在下载边界切断序列"
 
 msgid "Days"
 msgstr "日"
@@ -74,22 +89,22 @@ msgstr "日"
 msgid "Delete after upload"
 msgstr "上传后删除"
 
-#, java-format
 msgid "Deleted {0} image"
 msgid_plural "Deleted {0} images"
 msgstr[0] "已删除 {0} 张图像"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Display hour when the picture was taken"
 msgstr "显示图片拍摄时间"
 
 msgid "Displays detail information on the currently selected Mapillary image"
 msgstr "在当前选择的Mapillary图像上显示详细信息"
 
+msgid "Displays objects detected by Mapillary from their street view imagery"
+msgstr "显示由Mapillary从街景识别的对象"
+
 msgid "Displays the layer displaying the map objects detected by Mapillary"
 msgstr "显示Mapillary侦测到的地图对象"
 
-#, java-format
 msgid ""
 "Do you really want to replace the current value <i>{0}</i> with the new "
 "value <i>{1}</i>?"
@@ -104,12 +119,26 @@ msgstr "下载模式"
 msgid "Downloaded images"
 msgstr "已下载图像"
 
-#. i18n: Checkbox label in JOSM settings
+msgid "Downloading Mapillary images"
+msgstr "下载Mapillary图像中"
+
+msgid "Downloading map objects failed!"
+msgstr "下载地图对象失败！"
+
+msgid "Downloading map objects…"
+msgstr "下载地图对象中……"
+
+msgid "Downloading…"
+msgstr "下载中……"
+
 msgid "Enable experimental beta-features (might be unstable)"
 msgstr "启用实验性功能（可能不稳定）"
 
 msgid "Explore"
 msgstr "浏览"
+
+msgid "Export Mapillary images"
+msgstr "导出Mapillary图像"
 
 msgid "Export all images"
 msgstr "导出所有图像"
@@ -120,6 +149,12 @@ msgstr "导出选定图像"
 msgid "Export selected sequence"
 msgstr "导出所选序列"
 
+msgid "Exporting Mapillary Images…"
+msgstr "导出Mapillary图像中……"
+
+msgid "Finished upload"
+msgstr "上传完成"
+
 msgid "Follow selected image"
 msgstr "跟随所选图像"
 
@@ -129,7 +164,6 @@ msgstr "从现有的图层中"
 msgid "From which source do you want to import images to the Mapillary layer?"
 msgstr "您想从何来源导入图像至Mapillary层？"
 
-#. i18n: traffic sign
 msgid "Give way"
 msgstr "让道"
 
@@ -141,6 +175,12 @@ msgstr "前往设置并在上传前登陆Mapillary"
 
 msgid "I got it, close this."
 msgstr "我已知晓，关闭该窗口"
+
+msgid "Image actions"
+msgstr "图像动作"
+
+msgid "Image detections"
+msgstr "图像识别"
 
 msgid "Image info"
 msgstr "图片信息"
@@ -166,12 +206,10 @@ msgstr "将图像导入Mapillary层"
 msgid "Imported images"
 msgstr "已导入图像"
 
-#, java-format
 msgid "Imported {0} image"
 msgid_plural "Imported {0} images"
 msgstr[0] "已导入 {0} 张图像"
 
-#. i18n: traffic sign
 msgid "Intersection danger"
 msgstr "危险交叉"
 
@@ -195,7 +233,6 @@ msgstr "登录成功，返回 JOSM。"
 msgid "Logout"
 msgstr "注销"
 
-#. i18n: traffic sign
 msgid "Mandatory direction (any)"
 msgstr "强制性指示（任何）"
 
@@ -223,7 +260,6 @@ msgstr "Mapillary对象层"
 msgid "Months"
 msgstr "月"
 
-#, java-format
 msgid "Moved {0} image"
 msgid_plural "Moved {0} images"
 msgstr[0] "已移动 {0} 张图像"
@@ -231,25 +267,18 @@ msgstr[0] "已移动 {0} 张图像"
 msgid "Next picture"
 msgstr "前一图片"
 
-#. i18n: traffic sign
 msgid "No entry"
 msgstr "禁止入内"
-
-msgid "No image selected"
-msgstr "未选择图像"
 
 msgid "No images found"
 msgstr "没有找到图像"
 
-#. i18n: traffic sign
 msgid "No overtaking"
 msgstr "禁止超车"
 
-#. i18n: traffic sign
 msgid "No parking"
 msgstr "禁止停车"
 
-#. i18n: traffic sign
 msgid "No turn"
 msgstr "禁止掉头"
 
@@ -277,18 +306,15 @@ msgstr "暂停"
 msgid "Pauses the walk."
 msgstr "暂停步行"
 
-#. i18n: traffic sign
 msgid "Pedestrian crossing"
 msgstr "人行道十字路口"
 
 msgid "Play"
 msgstr "播放"
 
-#, java-format
 msgid "Press \"{0}\" to download images"
 msgstr "按\"{0}\"来下载图像"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Preview images when hovering its icon"
 msgstr "悬停在图标上时预览图像"
 
@@ -304,7 +330,6 @@ msgstr "重新设定"
 msgid "Rewrite imported images"
 msgstr "重写已导入图像"
 
-#. i18n: traffic sign
 msgid "Roundabout"
 msgstr "环岛"
 
@@ -323,7 +348,6 @@ msgstr "按序显示下一个图像"
 msgid "Shows the previous picture in the sequence"
 msgstr "按序显示上一个图像"
 
-#. i18n: traffic sign
 msgid "Speed limit"
 msgstr "限速"
 
@@ -331,7 +355,6 @@ msgctxt "as synonym to halt or stand still"
 msgid "Stop"
 msgstr "停车让行"
 
-#. i18n: traffic sign
 msgctxt "name of the traffic sign"
 msgid "Stop"
 msgstr "停车让行"
@@ -345,7 +368,6 @@ msgstr "提交修改集合"
 msgid "Submit the current changeset"
 msgstr "提交现有的修改集合"
 
-#. CHECKSTYLE.OFF: LineLength
 msgid "Submit the current changeset to Mapillary"
 msgstr "提交现有的修改集合至Mapillary"
 
@@ -367,7 +389,6 @@ msgstr "当前没有图层含有地理标签图像"
 msgid "Undo"
 msgstr "撤消"
 
-#. i18n: traffic sign
 msgid "Uneven road"
 msgstr "不平整的路"
 
@@ -377,7 +398,6 @@ msgstr "更新"
 msgid "Upload selected sequence"
 msgstr "上传所选序列"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Use 24 hour format"
 msgstr "使用24小时格式"
 
@@ -399,7 +419,6 @@ msgstr "年"
 msgid "You are currently not logged in."
 msgstr "您尚未登录。"
 
-#, java-format
 msgid "You are logged in as ''{0}''."
 msgstr "您已登录为“{0}”。"
 
@@ -418,10 +437,8 @@ msgstr "挂起中"
 msgid "rejected"
 msgstr "已退回"
 
-#, java-format
 msgid "{0} images in {1} sequences"
 msgstr "{0}图像在{1}序列中"
 
-#. Plugin description for Mapillary
 msgid "Allows the user to work with pictures hosted at mapillary.com"
 msgstr "可使用户用 mapillary.com 上的图片工作"

--- a/src/main/po/zh_TW.po
+++ b/src/main/po/zh_TW.po
@@ -1,15 +1,15 @@
 # Translations for the JOSM plugin 'Mapillary' (zh_TW)
-# Copyright (C) 2018 
+# Copyright (C) 2020
 # This file is distributed under the same license as the josm-plugin_Mapillary package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
-#, fuzzy
+#
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: josm-plugin_Mapillary v1.5.16-14-g82b2768\n"
+"Project-Id-Version: josm-plugin_Mapillary 1.5.20-3-ge40f8de\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-30 10:39+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"POT-Creation-Date: 2020-02-17 00:25+0000\n"
+"PO-Revision-Date: 2018-01-15 10:33+0000\n"
 "Language-Team: Chinese (Taiwan) (https://www.transifex.com/josm/teams/2544/zh_TW/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -23,7 +23,6 @@ msgstr "加入了 2 個影像"
 msgid "2 images unjoined"
 msgstr "退出了 2 個影像"
 
-#, java-format
 msgid ""
 "A tag with key <i>{0}</i> is already present on the selected OSM object."
 msgstr "有鍵 <i>{0}</i>已經存在選取的 OSM 物件上面了。"
@@ -47,12 +46,10 @@ msgstr "嘗試送出變更組合時發生例外狀況發生了。如果重覆發
 msgid "Cancel"
 msgstr "取消"
 
-#. i18n: Checkbox label in JOSM settings
 msgid ""
 "Center view on new image when using the buttons to jump to another image"
 msgstr "使用按鈕跳到其他影像時，置中新的影像"
 
-#, java-format
 msgid "Changeset upload failed with {0} error ''{1} {2}''!"
 msgstr "上傳變更組合因 {0} error ''{1} {2}'' 失敗！"
 
@@ -68,28 +65,26 @@ msgstr "複製鍵值"
 msgid "Could not import a geotagged image to the Mapillary layer!"
 msgstr "無法匯入有地理標記圖片到 Mapillary 圖層！"
 
-#, java-format
 msgid "Could not import the directory ''{0}''!"
 msgstr "無法匯入目錄 ''{0}''！"
 
-#, java-format
 msgid "Could not import the image ''{0}''!"
 msgstr "無法匯入圖片 ''{0}''！"
 
-#, java-format
 msgid "Could not open the URL {0} in a browser"
 msgstr "無法用瀏覽器打開網址 {0}"
 
-#, java-format
 msgid "Could not read from URL {0}!"
 msgstr "無法讀取網址 {0}！"
 
 msgid "Current Mapillary changeset"
 msgstr "目前的 Mapillary 變更組合"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Cut off sequences at download bounds"
 msgstr "在下載邊界切斷片段"
+
+msgid "Dark mode for image display"
+msgstr "照片顯示的黑暗模式"
 
 msgid "Days"
 msgstr "日"
@@ -97,12 +92,10 @@ msgstr "日"
 msgid "Delete after upload"
 msgstr "上傳後刪除"
 
-#, java-format
 msgid "Deleted {0} image"
 msgid_plural "Deleted {0} images"
 msgstr[0] "刪除了 {0} 個影像"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Display hour when the picture was taken"
 msgstr "顯示圖片拍攝時的小時時間"
 
@@ -115,7 +108,6 @@ msgstr "顯示 Mapillary 從街景偵測到的物件"
 msgid "Displays the layer displaying the map objects detected by Mapillary"
 msgstr "顯示 Mapillary 偵測出來的地圖物件的圖層"
 
-#, java-format
 msgid ""
 "Do you really want to replace the current value <i>{0}</i> with the new "
 "value <i>{1}</i>?"
@@ -142,7 +134,6 @@ msgstr "下載地圖物件..."
 msgid "Downloading…"
 msgstr "正在下載..."
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Enable experimental beta-features (might be unstable)"
 msgstr "啟用實驗性質的 beta 功能 (可能不穩定)"
 
@@ -176,7 +167,6 @@ msgstr "跟隨既有圖片圖層"
 msgid "From which source do you want to import images to the Mapillary layer?"
 msgstr "你要從那個來源匯入圖片到 Mapillary 圖層？"
 
-#. i18n: traffic sign
 msgid "Give way"
 msgstr "禮讓路口"
 
@@ -222,12 +212,10 @@ msgstr "匯入圖片到 Mapillary 圖層"
 msgid "Imported images"
 msgstr "匯入的圖片"
 
-#, java-format
 msgid "Imported {0} image"
 msgid_plural "Imported {0} images"
 msgstr[0] "匯入了 {0} 個影像"
 
-#. i18n: traffic sign
 msgid "Intersection danger"
 msgstr "路口危險"
 
@@ -266,7 +254,6 @@ msgstr "登入成功，回去 JOSM。"
 msgid "Logout"
 msgstr "登出"
 
-#. i18n: traffic sign
 msgid "Mandatory direction (any)"
 msgstr "強制性方向 (任何方向)"
 
@@ -303,7 +290,6 @@ msgstr "Mapillary 物件"
 msgid "Months"
 msgstr "月"
 
-#, java-format
 msgid "Moved {0} image"
 msgid_plural "Moved {0} images"
 msgstr[0] "移動了 {0} 個影像"
@@ -311,25 +297,18 @@ msgstr[0] "移動了 {0} 個影像"
 msgid "Next picture"
 msgstr "下一張圖片"
 
-#. i18n: traffic sign
 msgid "No entry"
 msgstr "沒有輸入"
-
-msgid "No image selected"
-msgstr "沒有選取圖片"
 
 msgid "No images found"
 msgstr "找不到影像"
 
-#. i18n: traffic sign
 msgid "No overtaking"
 msgstr "禁止超車"
 
-#. i18n: traffic sign
 msgid "No parking"
 msgstr "禁止停車"
 
-#. i18n: traffic sign
 msgid "No turn"
 msgstr "禁止轉彎"
 
@@ -339,7 +318,6 @@ msgstr "沒有登入 Mapillary"
 msgid "Not older than: "
 msgstr "不早於： "
 
-#. i18n: Spinner label in JOSM settings
 msgid "Number of images to be pre-fetched (forwards and backwards)"
 msgstr "要預載的圖片數目 (向前和向後)"
 
@@ -367,18 +345,15 @@ msgstr "暫停"
 msgid "Pauses the walk."
 msgstr "暫停走動"
 
-#. i18n: traffic sign
 msgid "Pedestrian crossing"
 msgstr "行人穿越"
 
 msgid "Play"
 msgstr "播放"
 
-#, java-format
 msgid "Press \"{0}\" to download images"
 msgstr "按 \"{0}\" 下載影像"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Preview images when hovering its icon"
 msgstr "滑動圖示過去時預纜圖片"
 
@@ -394,7 +369,6 @@ msgstr "重新設定"
 msgid "Rewrite imported images"
 msgstr "重新寫入匯入圖片"
 
-#. i18n: traffic sign
 msgid "Roundabout"
 msgstr "圓環"
 
@@ -422,7 +396,6 @@ msgstr "從片段顯示下一張"
 msgid "Shows the previous picture in the sequence"
 msgstr "從片段顯示上一張圖片"
 
-#. i18n: traffic sign
 msgid "Speed limit"
 msgstr "速限"
 
@@ -430,7 +403,6 @@ msgctxt "as synonym to halt or stand still"
 msgid "Stop"
 msgstr "禁止通行"
 
-#. i18n: traffic sign
 msgctxt "name of the traffic sign"
 msgid "Stop"
 msgstr "禁止通行"
@@ -444,7 +416,6 @@ msgstr "提出變更組合"
 msgid "Submit the current changeset"
 msgstr "提出目前的變更組合"
 
-#. CHECKSTYLE.OFF: LineLength
 msgid "Submit the current changeset to Mapillary"
 msgstr "提出目前的變更組合到 Mapillary"
 
@@ -475,7 +446,6 @@ msgstr ""
 msgid "There are currently no layers with geotagged images!"
 msgstr "目前圖層中並無地理標記的圖片！"
 
-#, java-format
 msgid ""
 "To solve this problem, you could switch to download mode ''{0}'' and load "
 "Mapillary images for a smaller portion of the map."
@@ -488,11 +458,9 @@ msgstr "要解決這項問題，你可以放大然後載入地圖比較小的部
 msgid "Too many map objects, zoom in to see all."
 msgstr "太多地圖物件，放大後來看所有物件。"
 
-#, java-format
 msgid "Total Mapillary images: {0}"
 msgstr "所有 Mapillary 圖片： {0}"
 
-#, java-format
 msgid "Turned {0} image"
 msgid_plural "Turned {0} images"
 msgstr[0] "旋轉了 {0} 個影像"
@@ -500,7 +468,6 @@ msgstr[0] "旋轉了 {0} 個影像"
 msgid "Undo"
 msgstr "復原"
 
-#. i18n: traffic sign
 msgid "Uneven road"
 msgstr "坎坷的道路"
 
@@ -513,11 +480,9 @@ msgstr "上傳 Mapillary 圖片"
 msgid "Upload selected sequence"
 msgstr "上傳選取片段"
 
-#, java-format
 msgid "Uploading: {0}"
 msgstr "上傳中：{0}"
 
-#. i18n: Checkbox label in JOSM settings
 msgid "Use 24 hour format"
 msgstr "使用 24 小時格式"
 
@@ -536,7 +501,6 @@ msgstr "行走模式"
 msgid "Walk mode: Waiting for next image takes too long! Exiting walk mode…"
 msgstr "行走模式：等待下個影像太久了！離開行走模式..."
 
-#. i18n: Checkbox label in JOSM settings
 msgid ""
 "When opening Mapillary image in web browser, show the blur editor instead of"
 " the image viewer"
@@ -551,14 +515,17 @@ msgstr "年"
 msgid "You are currently not logged in."
 msgstr "你目前沒登入。"
 
-#, java-format
 msgid "You are logged in as ''{0}''."
 msgstr "你已經登入為 ''{0}''。"
 
 msgid "You are not logged in, please log in to Mapillary in the preferences"
 msgstr "你並沒有登入，請在偏好設定登入 Mapillary"
 
-#, java-format
+msgid ""
+"You are trying to upload a sequence to mapillary.com that you previously "
+"downloaded from there. That is not possible."
+msgstr "你嘗試上傳片段到 mapillary.com，但先前已經從這裡下載了，這並不可能。"
+
 msgid "You have successfully uploaded {0} image to mapillary.com"
 msgid_plural "You have successfully uploaded {0} images to mapillary.com"
 msgstr[0] "你成功上傳 {0} 圖片到 mapillary.com"
@@ -572,18 +539,18 @@ msgstr "縮放到目前選取的 Mapiilary 影像"
 msgid "approved"
 msgstr "批准"
 
-#. i18n: download mode for Mapillary images
 msgid "areas with downloaded OSM-data"
 msgstr "區域已經有下載下來的 OSM 資料"
 
-#. i18n: download mode for Mapillary images
 msgid "everything in the visible area"
 msgstr "所有東西都在可視範圍"
 
 msgid "image has no key"
 msgstr "圖片沒有鍵"
 
-#. i18n: download mode for Mapillary images
+msgid "no image selected"
+msgstr "沒有選擇照片"
+
 msgid "only when manually requested"
 msgstr "只有當手動要求時"
 
@@ -599,7 +566,6 @@ msgstr "片段沒有鍵"
 msgid "unknown user"
 msgstr "未知的使用者"
 
-#, java-format
 msgid ""
 "{0}\n"
 "Could not read map objects from URL\n"
@@ -608,46 +574,36 @@ msgstr ""
 "{0}\n"
 "無法從網址 {1} 讀取地圖物件！"
 
-#. i18n: {0} is the layer name, {1} the number of images in it
-#, java-format
 msgid "{0} ({1} image)"
 msgid_plural "{0} ({1} images)"
 msgstr[0] "{0} ({1} 圖片)"
 
-#, java-format
 msgid "{0} detections"
 msgstr "方向 {0} "
 
-#, java-format
 msgid "{0} downloaded image"
 msgid_plural "{0} downloaded images"
 msgstr[0] "下載 {0} 張圖片"
 
-#, java-format
 msgid "{0} image in total"
 msgid_plural "{0} images in total"
 msgstr[0] "總共 {0} 張圖片"
 
-#, java-format
 msgid "{0} image submitted, Changeset key: {1}, State: {2}"
 msgid_plural "{0} images submitted, Changeset key: {1}, State: {2}"
 msgstr[0] "{0} 圖片提交，變更組合鍵：{1}，狀態： {2}"
 
-#, java-format
 msgid "{0} images in {1} sequences"
 msgstr "{1} 片段有 {0} 張圖片"
 
-#, java-format
 msgid "{0} imported image"
 msgid_plural "{0} imported images"
 msgstr[0] "匯入 {0} 張圖片"
 
-#, java-format
 msgid "{0} sequence, containing between {1} and {2} images (ø {3})"
 msgid_plural ""
 "{0} sequences, each containing between {1} and {2} images (ø {3})"
 msgstr[0] "{0} 片段，每個片段含有 {1} 到 {2} 張圖片 (ø {3})"
 
-#. Plugin description for Mapillary
 msgid "Allows the user to work with pictures hosted at mapillary.com"
 msgstr "Mapillary外掛"

--- a/test/unit/org/openstreetmap/josm/plugins/mapillary/ImportTest.java
+++ b/test/unit/org/openstreetmap/josm/plugins/mapillary/ImportTest.java
@@ -36,8 +36,6 @@ public class ImportTest {
 
   /**
    * Test if provided an invalid file, the proper exception is thrown.
-   *
-   * @throws IOException
    */
   @Test(expected = IIOException.class)
   public void testInvalidFiles() throws IOException {

--- a/test/unit/org/openstreetmap/josm/plugins/mapillary/MapillaryLayerTest.java
+++ b/test/unit/org/openstreetmap/josm/plugins/mapillary/MapillaryLayerTest.java
@@ -72,7 +72,7 @@ public class MapillaryLayerTest {
   @Test
   public void testGetChangesetSourceTag() {
     String actualChangesetSourceTag = MapillaryLayer.getInstance().getChangesetSourceTag();
-    assertEquals("OpenStreetmap changeset source for Mapillary layer should be 'mapillary'", "mapillary", actualChangesetSourceTag);
+    assertEquals("OpenStreetmap changeset source for Mapillary layer should be 'Mapillary'", "Mapillary", actualChangesetSourceTag);
   }
 
   @Test

--- a/test/unit/org/openstreetmap/josm/plugins/mapillary/MapillaryLayerTest.java
+++ b/test/unit/org/openstreetmap/josm/plugins/mapillary/MapillaryLayerTest.java
@@ -1,6 +1,7 @@
 // License: GPL. For details, see LICENSE file.
 package org.openstreetmap.josm.plugins.mapillary;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -66,6 +67,12 @@ public class MapillaryLayerTest {
     Object comp = MapillaryLayer.getInstance().getInfoComponent();
     assertTrue(comp instanceof String);
     assertTrue(((String) comp).length() >= 9);
+  }
+
+  @Test
+  public void testGetChangesetSourceTag() {
+    String actualChangesetSourceTag = MapillaryLayer.getInstance().getChangesetSourceTag();
+    assertEquals("OpenStreetmap changeset source for Mapillary layer should be 'mapillary'", "mapillary", actualChangesetSourceTag);
   }
 
   @Test

--- a/test/unit/org/openstreetmap/josm/plugins/mapillary/MapillaryLayerTest.java
+++ b/test/unit/org/openstreetmap/josm/plugins/mapillary/MapillaryLayerTest.java
@@ -4,6 +4,7 @@ package org.openstreetmap.josm.plugins.mapillary;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -13,8 +14,12 @@ import org.junit.Test;
 
 import org.openstreetmap.josm.data.coor.LatLon;
 import org.openstreetmap.josm.data.imagery.ImageryInfo;
+import org.openstreetmap.josm.data.osm.DataSet;
+import org.openstreetmap.josm.data.osm.Node;
+import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.gui.layer.ImageryLayer;
 import org.openstreetmap.josm.gui.layer.Layer;
+import org.openstreetmap.josm.gui.layer.OsmDataLayer;
 import org.openstreetmap.josm.plugins.mapillary.utils.TestUtil.MapillaryTestRules;
 import org.openstreetmap.josm.testutils.JOSMTestRules;
 
@@ -70,9 +75,43 @@ public class MapillaryLayerTest {
   }
 
   @Test
+  public void testSetImageViewed() {
+    MapillaryImage image = new MapillaryImage("0", LatLon.ZERO, 0, false);
+    assertFalse("An image should not be set as viewed if there is no image or dataset",
+        MapillaryLayer.getInstance().setImageViewed(null));
+    assertFalse("An image should not be set as viewed if there is no dataset to edit",
+        MapillaryLayer.getInstance().setImageViewed(image));
+    MainApplication.getLayerManager().addLayer(new OsmDataLayer(new DataSet(), "Test Layer", null));
+    assertFalse("An image should not be set as viewed if there is no image (i.e., image is null)",
+        MapillaryLayer.getInstance().setImageViewed(null));
+    assertTrue("An image should be set as viewed if there is an image and a dataset",
+        MapillaryLayer.getInstance().setImageViewed(image));
+  }
+
+  @Test
   public void testGetChangesetSourceTag() {
     String actualChangesetSourceTag = MapillaryLayer.getInstance().getChangesetSourceTag();
+    assertNull("OpenStreetmap changeset source for Mapillary layer should be 'null' when there is no dataset",
+        actualChangesetSourceTag);
+    DataSet ds = new DataSet();
+    Node node = new Node(LatLon.ZERO);
+    ds.addPrimitive(node);
+    node.setModified(true);
+    MapillaryImage image = new MapillaryImage("0", LatLon.ZERO, 0, false);
+    MainApplication.getLayerManager().addLayer(new OsmDataLayer(ds, "Test Layer", null));
+    MapillaryLayer.getInstance().setImageViewed(image);
+    actualChangesetSourceTag = MapillaryLayer.getInstance().getChangesetSourceTag();
     assertEquals("OpenStreetmap changeset source for Mapillary layer should be 'Mapillary'", "Mapillary", actualChangesetSourceTag);
+    node.setCoor(LatLon.NORTH_POLE);
+    actualChangesetSourceTag = MapillaryLayer.getInstance().getChangesetSourceTag();
+    assertNull(
+        "OpenStreetmap changeset source for Mapillary layer should be 'null' when the viewed images are very far from the modified objects",
+        actualChangesetSourceTag);
+    node.setCoor(new LatLon(0.0049, 0.0049));
+    actualChangesetSourceTag = MapillaryLayer.getInstance().getChangesetSourceTag();
+    assertNull(
+        "OpenStreetmap changeset source for Mapillary layer should be 'null' when the viewed images are more than 30.0m away (default)",
+        actualChangesetSourceTag);
   }
 
   @Test

--- a/test/unit/org/openstreetmap/josm/plugins/mapillary/utils/api/JsonImageDetailsDecoderTest.java
+++ b/test/unit/org/openstreetmap/josm/plugins/mapillary/utils/api/JsonImageDetailsDecoderTest.java
@@ -83,8 +83,7 @@ public class JsonImageDetailsDecoderTest {
     private int imageRetrievals;
 
     /**
-     * Returns how often the method {@link #getImages()} has been accessed for this instance.
-     * @return
+     * @return how often the method {@link #getImages()} has been accessed for this instance.
      */
     public int getNumImageRerievals() {
       return imageRetrievals;


### PR DESCRIPTION
Improve Mapillary source detection so that the "Mapillary" source tag only appears when relevant (relevant, in this case, means that something was modified within a certain distance of a Mapillary image that was shown while the data layer was active).

The distance defaults to 30.0m, but can be changed with `mapillary.source.maxdistance`. At this time, JOSM doesn't have a good way to extend a bbox by an arbitrary measurement (i.e., meters), so greatly increasing `mapillary.source.maxdistance` will be inadvisable at >80 degrees N/S, and the default bbox expansion to get items to check may be too small at >85 degree angles.

There is a new TODO (depends upon JOSM-18731), but the TODO is strictly optional at this time.

There is a bump in the minimum required JOSM version, since `BBox#addLatLon(LatLon latlon, double extraSpace)` was added in JOSM 15877.

There will be another bump when JOSM-18731 is fixed and the TODO item is done.