### PR TITLE
Feature/authentication private repos

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,11 +6,11 @@ plugin.icon=images/mapillary-logo.svg
 plugin.link=https://wiki.openstreetmap.org/wiki/JOSM/Plugins/Mapillary
 # Minimum required JOSM version to run this plugin, choose the lowest version possible that is compatible.
 # You can check if the plugin compiles against this version by executing `./gradlew compileJava_minJosm`.
-plugin.main.version=15885
+plugin.main.version=15909
 # Version of JOSM against which the plugin is compiled
 # Please check, if the specified version is available for download from https://josm.openstreetmap.de/download/ .
 # If not, choose the next higher number that is available, or the gradle build will break.
-plugin.compile.version=15885
+plugin.compile.version=15909
 plugin.requires=apache-commons;apache-http
 
 # Character encoding of Gradle files

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/MapillaryAbstractImage.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/MapillaryAbstractImage.java
@@ -1,6 +1,7 @@
 // License: GPL. For details, see LICENSE file.
 package org.openstreetmap.josm.plugins.mapillary;
 
+import java.awt.Color;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
@@ -304,4 +305,16 @@ public abstract class MapillaryAbstractImage implements Comparable<MapillaryAbst
   public void turn(final double ca) {
     this.movingCa = this.tempCa + ca;
   }
+
+  public abstract Color paintHighlightedColour();
+
+  public abstract Color paintHighlightedAngleColour();
+
+  public abstract Color paintSelectedColour();
+
+  public abstract Color paintSelectedAngleColour();
+
+  public abstract Color paintUnselectedColour();
+
+  public abstract Color paintUnselectedAngleColour();
 }

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/MapillaryImage.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/MapillaryImage.java
@@ -1,6 +1,7 @@
 // License: GPL. For details, see LICENSE file.
 package org.openstreetmap.josm.plugins.mapillary;
 
+import java.awt.Color;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -9,6 +10,7 @@ import java.util.List;
 import org.openstreetmap.josm.data.coor.LatLon;
 import org.openstreetmap.josm.plugins.mapillary.model.ImageDetection;
 import org.openstreetmap.josm.plugins.mapillary.model.UserProfile;
+import org.openstreetmap.josm.plugins.mapillary.utils.MapillaryColorScheme;
 import org.openstreetmap.josm.tools.Logging;
 
 /**
@@ -27,6 +29,10 @@ public class MapillaryImage extends MapillaryAbstractImage {
    * Set of traffic signs in the image.
    */
   private final List<ImageDetection> detections = Collections.synchronizedList(new ArrayList<>());
+  /**
+   * If {@code true}, the image is private. If {@code false}, then it is public.
+   */
+  private boolean privateImage;
 
   /**
    * Main constructor of the class MapillaryImage
@@ -36,9 +42,11 @@ public class MapillaryImage extends MapillaryAbstractImage {
    * @param ca     The direction of the images in degrees, meaning 0 north.
    * @param pano   The property to indicate whether image is panorama or not.
    */
-  public MapillaryImage(final String key, final LatLon latLon, final double ca, final boolean pano) {
+  public MapillaryImage(final String key, final LatLon latLon, final double ca, final boolean pano,
+      final boolean privateImage) {
     super(latLon, ca, pano);
     this.key = key;
+    this.privateImage = privateImage;
   }
 
   /**
@@ -112,5 +120,35 @@ public class MapillaryImage extends MapillaryAbstractImage {
   public void turn(double ca) {
     super.turn(ca);
     checkModified();
+  }
+
+  @Override
+  public Color paintHighlightedColour() {
+    return privateImage ? MapillaryColorScheme.SEQ_PRIVATE_HIGHLIGHTED : MapillaryColorScheme.SEQ_HIGHLIGHTED;
+  }
+
+  @Override
+  public Color paintHighlightedAngleColour() {
+    return privateImage ? MapillaryColorScheme.SEQ_PRIVATE_HIGHLIGHTED_CA : MapillaryColorScheme.SEQ_HIGHLIGHTED_CA;
+  }
+
+  @Override
+  public Color paintSelectedColour() {
+    return privateImage ? MapillaryColorScheme.SEQ_PRIVATE_SELECTED : MapillaryColorScheme.SEQ_SELECTED;
+  }
+
+  @Override
+  public Color paintSelectedAngleColour() {
+    return privateImage ? MapillaryColorScheme.SEQ_PRIVATE_SELECTED_CA : MapillaryColorScheme.SEQ_SELECTED_CA;
+  }
+
+  @Override
+  public Color paintUnselectedColour() {
+    return privateImage ? MapillaryColorScheme.SEQ_PRIVATE_UNSELECTED : MapillaryColorScheme.SEQ_UNSELECTED;
+  }
+
+  @Override
+  public Color paintUnselectedAngleColour() {
+    return privateImage ? MapillaryColorScheme.SEQ_PRIVATE_UNSELECTED_CA : MapillaryColorScheme.SEQ_UNSELECTED_CA;
   }
 }

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/MapillaryImportedImage.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/MapillaryImportedImage.java
@@ -1,6 +1,7 @@
 // License: GPL. For details, see LICENSE file.
 package org.openstreetmap.josm.plugins.mapillary;
 
+import java.awt.Color;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.FileInputStream;
@@ -16,6 +17,7 @@ import org.openstreetmap.josm.gui.MapView;
 import org.openstreetmap.josm.gui.layer.geoimage.GeoImageLayer;
 import org.openstreetmap.josm.gui.layer.geoimage.ImageEntry;
 import org.openstreetmap.josm.plugins.mapillary.utils.ImageMetaDataUtil;
+import org.openstreetmap.josm.plugins.mapillary.utils.MapillaryColorScheme;
 import org.openstreetmap.josm.plugins.mapillary.utils.MapillaryUtils;
 import org.openstreetmap.josm.tools.Logging;
 
@@ -162,4 +164,35 @@ public class MapillaryImportedImage extends MapillaryAbstractImage {
     }
     return true;
   }
+
+  @Override
+  public Color paintHighlightedColour() {
+    return MapillaryColorScheme.SEQ_IMPORTED_HIGHLIGHTED;
+  }
+
+  @Override
+  public Color paintHighlightedAngleColour() {
+    return MapillaryColorScheme.SEQ_IMPORTED_HIGHLIGHTED_CA;
+  }
+
+  @Override
+  public Color paintSelectedColour() {
+    return MapillaryColorScheme.SEQ_IMPORTED_SELECTED;
+  }
+
+  @Override
+  public Color paintSelectedAngleColour() {
+    return MapillaryColorScheme.SEQ_IMPORTED_SELECTED_CA;
+  }
+
+  @Override
+  public Color paintUnselectedColour() {
+    return MapillaryColorScheme.SEQ_IMPORTED_UNSELECTED;
+  }
+
+  @Override
+  public Color paintUnselectedAngleColour() {
+    return MapillaryColorScheme.SEQ_IMPORTED_UNSELECTED_CA;
+  }
+
 }

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/MapillaryLayer.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/MapillaryLayer.java
@@ -34,6 +34,7 @@ import javax.swing.Action;
 import javax.swing.Icon;
 import javax.swing.JComponent;
 import javax.swing.KeyStroke;
+import javax.swing.SwingUtilities;
 
 import org.openstreetmap.josm.actions.UploadAction;
 import org.openstreetmap.josm.actions.upload.UploadHook;
@@ -625,8 +626,11 @@ public final class MapillaryLayer extends AbstractModifiableLayer implements
       nearestImages = new MapillaryImage[0];
     }
     if (MainApplication.isDisplayingMapView()) {
-      MapillaryMainDialog.getInstance().redButton.setEnabled(nearestImages.length >= 1);
-      MapillaryMainDialog.getInstance().blueButton.setEnabled(nearestImages.length >= 2);
+      if (SwingUtilities.isEventDispatchThread()) {
+        updateRedBlueButtons();
+      } else {
+        SwingUtilities.invokeLater(() -> updateRedBlueButtons());
+      }
     }
     if (nearestImages.length >= 1) {
       CacheUtils.downloadPicture(nearestImages[0]);
@@ -634,6 +638,11 @@ public final class MapillaryLayer extends AbstractModifiableLayer implements
         CacheUtils.downloadPicture(nearestImages[1]);
       }
     }
+  }
+
+  private void updateRedBlueButtons() {
+    MapillaryMainDialog.getInstance().redButton.setEnabled(nearestImages.length >= 1);
+    MapillaryMainDialog.getInstance().blueButton.setEnabled(nearestImages.length >= 2);
   }
 
   /**

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/MapillaryLayer.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/MapillaryLayer.java
@@ -15,7 +15,6 @@ import java.awt.event.ActionEvent;
 import java.awt.geom.Line2D;
 import java.awt.geom.Path2D;
 import java.awt.image.BufferedImage;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -462,10 +461,7 @@ public final class MapillaryLayer extends AbstractModifiableLayer implements
           BBox bbox = new BBox();
           bbox.addLatLon(image.getLatLon(), 0.005); // 96m-556m, depending upon N/S location (low at 80 degrees, high at
                                                     // 0)
-          // TODO use {@link DataSet#searchPrimitives} which requires #18731
-          List<OsmPrimitive> searchPrimitives = new ArrayList<>(ds.searchNodes(bbox));
-          searchPrimitives.addAll(ds.searchWays(bbox));
-          searchPrimitives.addAll(ds.searchRelations(bbox));
+          List<OsmPrimitive> searchPrimitives = ds.searchPrimitives(bbox);
           if (primitives.parallelStream().filter(searchPrimitives::contains)
               .mapToDouble(prim -> Geometry.getDistance(prim, new Node(image.getLatLon())))
               .anyMatch(d -> d < maxDistance)) {

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/MapillaryLayer.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/MapillaryLayer.java
@@ -396,26 +396,14 @@ public final class MapillaryLayer extends AbstractModifiableLayer implements
     final Color markerC;
     final Color directionC;
     if (selectedImg != null && getData().getMultiSelectedImages().contains(img)) {
-      markerC = img instanceof MapillaryImportedImage
-        ? MapillaryColorScheme.SEQ_IMPORTED_HIGHLIGHTED
-        : MapillaryColorScheme.SEQ_HIGHLIGHTED;
-      directionC = img instanceof MapillaryImportedImage
-        ? MapillaryColorScheme.SEQ_IMPORTED_HIGHLIGHTED_CA
-        : MapillaryColorScheme.SEQ_HIGHLIGHTED_CA;
+      markerC = img.paintHighlightedColour();
+      directionC = img.paintHighlightedAngleColour();
     } else if (selectedImg != null && selectedImg.getSequence() != null && selectedImg.getSequence().equals(img.getSequence())) {
-      markerC = img instanceof MapillaryImportedImage
-        ? MapillaryColorScheme.SEQ_IMPORTED_SELECTED
-        : MapillaryColorScheme.SEQ_SELECTED;
-      directionC = img instanceof MapillaryImportedImage
-        ? MapillaryColorScheme.SEQ_IMPORTED_SELECTED_CA
-        : MapillaryColorScheme.SEQ_SELECTED_CA;
+      markerC = img.paintSelectedColour();
+      directionC = img.paintSelectedAngleColour();
     } else {
-      markerC = img instanceof MapillaryImportedImage
-        ? MapillaryColorScheme.SEQ_IMPORTED_UNSELECTED
-        : MapillaryColorScheme.SEQ_UNSELECTED;
-      directionC = img instanceof MapillaryImportedImage
-        ? MapillaryColorScheme.SEQ_IMPORTED_UNSELECTED_CA
-        : MapillaryColorScheme.SEQ_UNSELECTED_CA;
+      markerC = img.paintUnselectedColour();
+      directionC = img.paintUnselectedAngleColour();
     }
 
     // Paint direction indicator

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryPreferenceSetting.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryPreferenceSetting.java
@@ -80,6 +80,9 @@ public class MapillaryPreferenceSetting implements SubPreferenceSetting, Mapilla
       I18n.tr("When opening Mapillary image in web browser, show the blur editor instead of the image viewer"),
       MapillaryProperties.IMAGE_LINK_TO_BLUR_EDITOR.get()
     );
+  private final JPanel requiresLogin = new JPanel();
+  private final JComboBox<String> privateImages = new JComboBox<>(
+      new String[] { I18n.tr("All Images"), I18n.tr("Private Images Only"), I18n.tr("Public Images Only") });
   private final JCheckBox developer =
     // i18n: Checkbox label in JOSM settings
     new JCheckBox(I18n.tr("Enable experimental beta-features (might be unstable)"), MapillaryProperties.DEVELOPER.get());
@@ -154,6 +157,11 @@ public class MapillaryPreferenceSetting implements SubPreferenceSetting, Mapilla
     preFetchPanel.add(spinner);
     mainPanel.add(preFetchPanel, GBC.eol());
 
+    requiresLogin.setLayout(new BoxLayout(requiresLogin, BoxLayout.PAGE_AXIS));
+    requiresLogin.add(new JLabel(I18n.tr("Image selection")), GBC.eop());
+    requiresLogin.add(privateImages, GBC.eol());
+    mainPanel.add(requiresLogin, GBC.eol());
+
     if (ExpertToggleAction.isExpert() || developer.isSelected()) {
       mainPanel.add(developer, GBC.eol());
     }
@@ -179,6 +187,7 @@ public class MapillaryPreferenceSetting implements SubPreferenceSetting, Mapilla
 
   @Override
   public void onLogin(final String username) {
+    requiresLogin.setVisible(true);
     loginPanel.remove(loginButton);
     loginPanel.add(logoutButton, 3);
     loginLabel.setText(I18n.tr("You are logged in as ''{0}''.", username));
@@ -188,6 +197,7 @@ public class MapillaryPreferenceSetting implements SubPreferenceSetting, Mapilla
 
   @Override
   public void onLogout() {
+    requiresLogin.setVisible(false);
     loginPanel.remove(logoutButton);
     loginPanel.add(loginButton, 3);
     loginLabel.setText(I18n.tr("You are currently not logged in."));
@@ -208,6 +218,7 @@ public class MapillaryPreferenceSetting implements SubPreferenceSetting, Mapilla
     MapillaryProperties.IMAGE_LINK_TO_BLUR_EDITOR.put(imageLinkToBlurEditor.isSelected());
     MapillaryProperties.DEVELOPER.put(developer.isSelected());
     MapillaryProperties.PRE_FETCH_IMAGE_COUNT.put(preFetchSize.getNumber().intValue());
+    MapillaryProperties.IMAGE_MODE.put(privateImages.getSelectedIndex());
 
     //Restart is never required
     return false;

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/io/download/BoundsDownloadRunnable.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/io/download/BoundsDownloadRunnable.java
@@ -12,6 +12,8 @@ import java.util.function.Function;
 import org.openstreetmap.josm.data.Bounds;
 import org.openstreetmap.josm.gui.Notification;
 import org.openstreetmap.josm.plugins.mapillary.MapillaryPlugin;
+import org.openstreetmap.josm.plugins.mapillary.oauth.MapillaryUser;
+import org.openstreetmap.josm.plugins.mapillary.oauth.OAuthUtils;
 import org.openstreetmap.josm.plugins.mapillary.utils.MapillaryURL.APIv3;
 import org.openstreetmap.josm.tools.I18n;
 import org.openstreetmap.josm.tools.ImageProvider.ImageSizes;
@@ -43,6 +45,8 @@ public abstract class BoundsDownloadRunnable implements Runnable {
           return;
         }
         final URLConnection con = nextURL.openConnection();
+        if (MapillaryUser.getUsername() != null)
+          OAuthUtils.addAuthenticationHeader(con);
         run(con);
         nextURL = APIv3.parseNextFromLinkHeaderValue(con.getHeaderField("Link"));
       }

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/io/download/BoundsDownloadRunnable.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/io/download/BoundsDownloadRunnable.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLConnection;
+import java.util.Collection;
 import java.util.function.Function;
 
 import org.openstreetmap.josm.data.Bounds;
@@ -19,7 +20,8 @@ import org.openstreetmap.josm.tools.Logging;
 public abstract class BoundsDownloadRunnable implements Runnable {
 
   protected final Bounds bounds;
-  protected abstract Function<Bounds, URL> getUrlGenerator();
+
+  protected abstract Function<Bounds, Collection<URL>> getUrlGenerator();
 
   public BoundsDownloadRunnable(final Bounds bounds) {
     this.bounds = bounds;
@@ -27,7 +29,13 @@ public abstract class BoundsDownloadRunnable implements Runnable {
 
   @Override
   public void run() {
-    URL nextURL = getUrlGenerator().apply(bounds);
+    Collection<URL> urls = getUrlGenerator().apply(bounds);
+    for (URL url : urls) {
+      realRun(url);
+    }
+  }
+
+  private void realRun(URL nextURL) {
     try {
       while (nextURL != null) {
         if (Thread.interrupted()) {

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/io/download/BoundsDownloadRunnable.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/io/download/BoundsDownloadRunnable.java
@@ -9,6 +9,8 @@ import java.net.URLConnection;
 import java.util.Collection;
 import java.util.function.Function;
 
+import javax.swing.SwingUtilities;
+
 import org.openstreetmap.josm.data.Bounds;
 import org.openstreetmap.josm.gui.Notification;
 import org.openstreetmap.josm.plugins.mapillary.MapillaryPlugin;
@@ -54,12 +56,18 @@ public abstract class BoundsDownloadRunnable implements Runnable {
       String message = I18n.tr("Could not read from URL {0}!", nextURL.toString());
       Logging.log(Logging.LEVEL_WARN, message, e);
       if (!GraphicsEnvironment.isHeadless()) {
-        new Notification(message)
-          .setIcon(MapillaryPlugin.LOGO.setSize(ImageSizes.LARGEICON).get())
-          .setDuration(Notification.TIME_LONG)
-          .show();
+        if (SwingUtilities.isEventDispatchThread()) {
+          showNotification(message);
+        } else {
+          SwingUtilities.invokeLater(() -> showNotification(message));
+        }
       }
     }
+  }
+
+  private static void showNotification(String message) {
+    new Notification(message).setIcon(MapillaryPlugin.LOGO.setSize(ImageSizes.LARGEICON).get())
+        .setDuration(Notification.TIME_LONG).show();
   }
 
   /**

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/io/download/DetectionsDownloadRunnable.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/io/download/DetectionsDownloadRunnable.java
@@ -5,6 +5,7 @@ import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -26,7 +27,7 @@ import org.openstreetmap.josm.plugins.mapillary.utils.api.JsonImageDetectionDeco
 
 public class DetectionsDownloadRunnable extends BoundsDownloadRunnable {
 
-  private static final Function<Bounds, URL> URL_GEN = APIv3::searchDetections;
+  private static final Function<Bounds, Collection<URL>> URL_GEN = APIv3::searchDetections;
 
   private final MapillaryData data;
 
@@ -57,7 +58,7 @@ public class DetectionsDownloadRunnable extends BoundsDownloadRunnable {
   }
 
   @Override
-  protected Function<Bounds, URL> getUrlGenerator() {
+  protected Function<Bounds, Collection<URL>> getUrlGenerator() {
     return URL_GEN;
   }
 }

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/io/download/ImageDetailsDownloadRunnable.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/io/download/ImageDetailsDownloadRunnable.java
@@ -5,6 +5,7 @@ import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.util.Collection;
 import java.util.function.Function;
 
 import javax.json.Json;
@@ -18,7 +19,7 @@ import org.openstreetmap.josm.plugins.mapillary.utils.MapillaryURL.APIv3;
 import org.openstreetmap.josm.plugins.mapillary.utils.api.JsonImageDetailsDecoder;
 
 public class ImageDetailsDownloadRunnable extends BoundsDownloadRunnable {
-  private static final Function<Bounds, URL> URL_GEN = APIv3::searchImages;
+  private static final Function<Bounds, Collection<URL>> URL_GEN = APIv3::searchImages;
 
   private final MapillaryData data;
 
@@ -39,7 +40,7 @@ public class ImageDetailsDownloadRunnable extends BoundsDownloadRunnable {
   }
 
   @Override
-  protected Function<Bounds, URL> getUrlGenerator() {
+  protected Function<Bounds, Collection<URL>> getUrlGenerator() {
     return URL_GEN;
   }
 

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/io/download/MapillaryDownloader.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/io/download/MapillaryDownloader.java
@@ -23,6 +23,39 @@ import org.openstreetmap.josm.tools.Logging;
  * @author nokutu
  */
 public final class MapillaryDownloader {
+  /** Possible public/private download options */
+  public enum PRIVATE_IMAGE_DOWNLOAD_MODE {
+    PUBLIC_ONLY("publicOnly", I18n.marktr("Only download public images")),
+    PRIVATE_ONLY("privateOnly", I18n.marktr("Only download private images")),
+    ALL("all", I18n.marktr("Download all available images"));
+
+    public final static PRIVATE_IMAGE_DOWNLOAD_MODE DEFAULT = ALL;
+
+    private final String prefId;
+    private final String label;
+
+    PRIVATE_IMAGE_DOWNLOAD_MODE(String prefId, String label) {
+      this.prefId = prefId;
+      this.label = label;
+    }
+
+    @Override
+    public String toString() {
+      return I18n.tr(label);
+    }
+
+    public String getPrefId() {
+      return prefId;
+    }
+
+    public static PRIVATE_IMAGE_DOWNLOAD_MODE getFromId(String prefId) {
+      for (PRIVATE_IMAGE_DOWNLOAD_MODE val : PRIVATE_IMAGE_DOWNLOAD_MODE.values()) {
+        if (val.prefId.equals(prefId))
+          return val;
+      }
+      return ALL;
+    }
+  }
 
   /** Possible download modes. */
   public enum DOWNLOAD_MODE {

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/io/download/SequenceDownloadRunnable.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/io/download/SequenceDownloadRunnable.java
@@ -23,7 +23,7 @@ import org.openstreetmap.josm.plugins.mapillary.utils.api.JsonSequencesDecoder;
 
 public final class SequenceDownloadRunnable extends BoundsDownloadRunnable {
   private final MapillaryData data;
-  private static final Function<Bounds, URL> URL_GEN = APIv3::searchSequences;
+  private static final Function<Bounds, Collection<URL>> URL_GEN = APIv3::searchSequences;
 
   public SequenceDownloadRunnable(final MapillaryData data, final Bounds bounds) {
     super(bounds);
@@ -71,7 +71,7 @@ public final class SequenceDownloadRunnable extends BoundsDownloadRunnable {
   }
 
   @Override
-  protected Function<Bounds, URL> getUrlGenerator() {
+  protected Function<Bounds, Collection<URL>> getUrlGenerator() {
     return URL_GEN;
   }
 }

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/oauth/OAuthUtils.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/oauth/OAuthUtils.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
 
 import javax.json.Json;
@@ -40,7 +41,7 @@ public final class OAuthUtils {
   public static JsonObject getWithHeader(URL url) throws IOException {
     HttpURLConnection con = (HttpURLConnection) url.openConnection();
     con.setRequestMethod("GET");
-    con.setRequestProperty("Authorization", "Bearer " + MapillaryProperties.ACCESS_TOKEN.get());
+    addAuthenticationHeader(con);
 
     try (
       JsonReader reader = Json.createReader(new BufferedReader(new InputStreamReader(con.getInputStream(), StandardCharsets.UTF_8)))
@@ -49,5 +50,17 @@ public final class OAuthUtils {
     } catch (JsonException e) {
       throw new IOException(e);
     }
+  }
+
+  /**
+   * Returns a URLConnection with an authorization header for use when making user
+   * specific API calls
+   *
+   * @param con The connection to add authentication headers to
+   * @return The URLConnection for easy chaining
+   */
+  public static URLConnection addAuthenticationHeader(URLConnection con) {
+    con.setRequestProperty("Authorization", "Bearer " + MapillaryProperties.ACCESS_TOKEN.get());
+    return con;
   }
 }

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryColorScheme.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryColorScheme.java
@@ -31,6 +31,13 @@ public final class MapillaryColorScheme {
    */
   public static final Color SEQ_HIGHLIGHTED_CA = new Color(0xf5b81a);
 
+  public static final Color SEQ_PRIVATE_SELECTED = new Color(0xdd9aff);
+  public static final Color SEQ_PRIVATE_SELECTED_CA = new Color(0xe4aeff);
+  public static final Color SEQ_PRIVATE_UNSELECTED = new Color(0xa900ff);
+  public static final Color SEQ_PRIVATE_UNSELECTED_CA = new Color(0xba33ff);
+  public static final Color SEQ_PRIVATE_HIGHLIGHTED = SEQ_HIGHLIGHTED;
+  public static final Color SEQ_PRIVATE_HIGHLIGHTED_CA = SEQ_HIGHLIGHTED_CA;
+
   public static final Color SEQ_IMPORTED_SELECTED = new Color(0xdddddd);
   public static final Color SEQ_IMPORTED_SELECTED_CA = SEQ_IMPORTED_SELECTED.brighter();
   public static final Color SEQ_IMPORTED_UNSELECTED = new Color(0x999999);

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryProperties.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryProperties.java
@@ -73,7 +73,7 @@ public final class MapillaryProperties {
    *
    * @see MapillaryPreferenceSetting#privateImages
    */
-  public static final IntegerProperty IMAGE_MODE = new IntegerProperty("mapillary.imageMode", 0);
+  public static final StringProperty IMAGE_MODE = new StringProperty("mapillary.imageMode", "all");
 
   private MapillaryProperties() {
     // Private constructor to avoid instantiation

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryProperties.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryProperties.java
@@ -9,6 +9,7 @@ import org.openstreetmap.josm.data.preferences.IntegerProperty;
 import org.openstreetmap.josm.data.preferences.NamedColorProperty;
 import org.openstreetmap.josm.data.preferences.StringProperty;
 import org.openstreetmap.josm.gui.layer.OsmDataLayer;
+import org.openstreetmap.josm.plugins.mapillary.gui.MapillaryPreferenceSetting;
 import org.openstreetmap.josm.plugins.mapillary.gui.imageinfo.ImageInfoPanel;
 import org.openstreetmap.josm.plugins.mapillary.io.download.MapillaryDownloader;
 
@@ -66,6 +67,13 @@ public final class MapillaryProperties {
    * The number of images to be prefetched when a mapillary image is selected
    */
   public static final IntegerProperty PRE_FETCH_IMAGE_COUNT = new IntegerProperty("mapillary.prefetch-image-count", 2);
+
+  /**
+   * Download all images, private images, or public images
+   *
+   * @see MapillaryPreferenceSetting#privateImages
+   */
+  public static final IntegerProperty IMAGE_MODE = new IntegerProperty("mapillary.imageMode", 0);
 
   private MapillaryProperties() {
     // Private constructor to avoid instantiation

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryURL.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryURL.java
@@ -203,7 +203,7 @@ public final class MapillaryURL {
         parts.put("redirect_uri", redirectURI);
       }
       parts.put("response_type", "token");
-      parts.put("scope", "user:read public:upload public:write private:read");
+      parts.put("scope", "user:read org:read public:upload public:write private:read");
       return string2URL(baseUrl, "connect", queryString(parts));
     }
 

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryURL.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryURL.java
@@ -197,7 +197,7 @@ public final class MapillaryURL {
         parts.put("redirect_uri", redirectURI);
       }
       parts.put("response_type", "token");
-      parts.put("scope", "user:read org:read public:upload public:write private:read");
+      parts.put("scope", "user:read public:upload public:write private:read");
       return string2URL(baseUrl, "connect", queryString(parts));
     }
 

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryURL.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryURL.java
@@ -6,11 +6,16 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
 import org.openstreetmap.josm.data.Bounds;
+import org.openstreetmap.josm.plugins.mapillary.oauth.MapillaryUser;
 import org.openstreetmap.josm.tools.Logging;
 
 public final class MapillaryURL {
@@ -41,20 +46,27 @@ public final class MapillaryURL {
       return string2URL(baseUrl, "changesets", queryString(null));
     }
 
-    public static URL searchDetections(Bounds bounds) {
-      return string2URL(baseUrl, "image_detections", queryString(bounds, TRAFFIC_SIGN_LAYER) + SORT_BY_KEY);
+    public static Collection<URL> searchDetections(Bounds bounds) {
+      return Collections
+          .singleton(string2URL(baseUrl, "image_detections", queryString(bounds, TRAFFIC_SIGN_LAYER) + SORT_BY_KEY));
     }
 
-    public static URL searchImages(Bounds bounds) {
-      return string2URL(baseUrl, "images", queryString(bounds));
+    public static Collection<URL> searchImages(Bounds bounds) {
+      return Collections.singleton(string2URL(baseUrl, "images", queryString(bounds)));
     }
 
     public static URL searchMapObjects(final Bounds bounds) {
       return string2URL(baseUrl, "map_features", queryString(bounds, TRAFFIC_SIGN_LAYER) + SORT_BY_KEY);
     }
 
-    public static URL searchSequences(final Bounds bounds) {
-      return string2URL(baseUrl, "sequences", queryString(bounds));
+    public static Collection<URL> searchSequences(final Bounds bounds) {
+      List<URL> urls = new ArrayList<>();
+      int imageMode = MapillaryProperties.IMAGE_MODE.get();
+      if (imageMode == 0 || imageMode == 2)
+        urls.add(string2URL(baseUrl, "sequences", queryString(bounds)));
+      if (MapillaryUser.getUsername() != null && (imageMode == 0 || imageMode == 1))
+        urls.add(string2URL(baseUrl, "sequences", queryString(bounds), "&private=true"));
+      return urls;
     }
 
     /**

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryURL.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryURL.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import org.openstreetmap.josm.data.Bounds;
+import org.openstreetmap.josm.plugins.mapillary.io.download.MapillaryDownloader.PRIVATE_IMAGE_DOWNLOAD_MODE;
 import org.openstreetmap.josm.plugins.mapillary.oauth.MapillaryUser;
 import org.openstreetmap.josm.tools.Logging;
 
@@ -61,11 +62,16 @@ public final class MapillaryURL {
 
     public static Collection<URL> searchSequences(final Bounds bounds) {
       List<URL> urls = new ArrayList<>();
-      int imageMode = MapillaryProperties.IMAGE_MODE.get();
-      if (imageMode == 0 || imageMode == 2)
-        urls.add(string2URL(baseUrl, "sequences", queryString(bounds)));
-      if (MapillaryUser.getUsername() != null && (imageMode == 0 || imageMode == 1))
+      PRIVATE_IMAGE_DOWNLOAD_MODE imageMode = PRIVATE_IMAGE_DOWNLOAD_MODE
+          .getFromId(MapillaryProperties.IMAGE_MODE.get());
+      // If the private=true|false is left out, all images are obtained (as of
+      // 2020-02-20).
+      if (imageMode == PRIVATE_IMAGE_DOWNLOAD_MODE.PUBLIC_ONLY)
+        urls.add(string2URL(baseUrl, "sequences", queryString(bounds), "&private=false"));
+      else if (MapillaryUser.getUsername() != null && imageMode == PRIVATE_IMAGE_DOWNLOAD_MODE.PRIVATE_ONLY)
         urls.add(string2URL(baseUrl, "sequences", queryString(bounds), "&private=true"));
+      else
+        urls.add(string2URL(baseUrl, "sequences", queryString(bounds)));
       return urls;
     }
 

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryURL.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryURL.java
@@ -197,7 +197,7 @@ public final class MapillaryURL {
         parts.put("redirect_uri", redirectURI);
       }
       parts.put("response_type", "token");
-      parts.put("scope", "user:read public:upload public:write");
+      parts.put("scope", "user:read org:read public:upload public:write private:read");
       return string2URL(baseUrl, "connect", queryString(parts));
     }
 

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryUtils.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryUtils.java
@@ -23,6 +23,7 @@ import org.openstreetmap.josm.plugins.mapillary.MapillaryAbstractImage;
 import org.openstreetmap.josm.plugins.mapillary.MapillaryLayer;
 import org.openstreetmap.josm.plugins.mapillary.MapillarySequence;
 import org.openstreetmap.josm.tools.I18n;
+import org.openstreetmap.josm.tools.OpenBrowser;
 
 /**
  * Set of utilities.
@@ -42,7 +43,9 @@ public final class MapillaryUtils {
    *
    * @param url The (not-null) URL that is going to be opened.
    * @throws IOException when the URL could not be opened
+   * @deprecated Use {@link OpenBrowser#displayUrl} instead
    */
+  @Deprecated
   public static void browse(URL url) throws IOException {
     if (url == null) {
       throw new IllegalArgumentException();

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/api/JsonSequencesDecoder.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/api/JsonSequencesDecoder.java
@@ -56,9 +56,10 @@ public final class JsonSequencesDecoder {
       final LatLon[] geometry = decodeLatLons(json.getJsonObject("geometry"));
       final int sequenceLength = Math.min(Math.min(cas.length, imageKeys.length), geometry.length);
       boolean pano = properties.getBoolean("pano", false);
+      boolean privateImage = properties.getBoolean("private", false);
       for (int i = 0; i < sequenceLength; i++) {
         if (cas[i] != null && imageKeys[i] != null && geometry[i] != null) {
-          final MapillaryImage img = new MapillaryImage(imageKeys[i], geometry[i], cas[i], pano);
+          final MapillaryImage img = new MapillaryImage(imageKeys[i], geometry[i], cas[i], pano, privateImage);
           result.add(img);
         }
       }

--- a/test/unit/org/openstreetmap/josm/plugins/mapillary/MapillaryAbstractImageTest.java
+++ b/test/unit/org/openstreetmap/josm/plugins/mapillary/MapillaryAbstractImageTest.java
@@ -56,7 +56,7 @@ public class MapillaryAbstractImageTest {
 
   @Test
   public void testIsModified() {
-    MapillaryImage img = new MapillaryImage("key___________________", new LatLon(0, 0), 0, false);
+    MapillaryImage img = new MapillaryImage("key___________________", new LatLon(0, 0), 0, false, false);
     assertFalse(img.isModified());
     img.turn(1e-4);
     img.stopMoving();

--- a/test/unit/org/openstreetmap/josm/plugins/mapillary/MapillaryDataTest.java
+++ b/test/unit/org/openstreetmap/josm/plugins/mapillary/MapillaryDataTest.java
@@ -38,10 +38,10 @@ public class MapillaryDataTest {
    */
   @Before
   public void setUp() {
-    this.img1 = new MapillaryImage("key1__________________", new LatLon(0.1, 0.1), 90, false);
-    this.img2 = new MapillaryImage("key2__________________", new LatLon(0.2, 0.2), 90, false);
-    this.img3 = new MapillaryImage("key3__________________", new LatLon(0.3, 0.3), 90, false);
-    this.img4 = new MapillaryImage("key4__________________", new LatLon(0.4, 0.4), 90, false);
+    this.img1 = new MapillaryImage("key1__________________", new LatLon(0.1, 0.1), 90, false, false);
+    this.img2 = new MapillaryImage("key2__________________", new LatLon(0.2, 0.2), 90, false, false);
+    this.img3 = new MapillaryImage("key3__________________", new LatLon(0.3, 0.3), 90, false, false);
+    this.img4 = new MapillaryImage("key4__________________", new LatLon(0.4, 0.4), 90, false, false);
     final MapillarySequence seq = new MapillarySequence();
 
     seq.add(Arrays.asList(img1, img2, img3, img4));
@@ -74,7 +74,7 @@ public class MapillaryDataTest {
   @Test
   public void sizeTest() {
     assertEquals(4, this.data.getImages().size());
-    this.data.add(new MapillaryImage("key5__________________", new LatLon(0.1, 0.1), 90, false));
+    this.data.add(new MapillaryImage("key5__________________", new LatLon(0.1, 0.1), 90, false, false));
     assertEquals(5, this.data.getImages().size());
   }
 

--- a/test/unit/org/openstreetmap/josm/plugins/mapillary/MapillaryLayerTest.java
+++ b/test/unit/org/openstreetmap/josm/plugins/mapillary/MapillaryLayerTest.java
@@ -76,7 +76,7 @@ public class MapillaryLayerTest {
 
   @Test
   public void testSetImageViewed() {
-    MapillaryImage image = new MapillaryImage("0", LatLon.ZERO, 0, false);
+    MapillaryImage image = new MapillaryImage("0", LatLon.ZERO, 0, false, false);
     assertFalse("An image should not be set as viewed if there is no image or dataset",
         MapillaryLayer.getInstance().setImageViewed(null));
     assertFalse("An image should not be set as viewed if there is no dataset to edit",
@@ -97,7 +97,7 @@ public class MapillaryLayerTest {
     Node node = new Node(LatLon.ZERO);
     ds.addPrimitive(node);
     node.setModified(true);
-    MapillaryImage image = new MapillaryImage("0", LatLon.ZERO, 0, false);
+    MapillaryImage image = new MapillaryImage("0", LatLon.ZERO, 0, false, false);
     MainApplication.getLayerManager().addLayer(new OsmDataLayer(ds, "Test Layer", null));
     MapillaryLayer.getInstance().setImageViewed(image);
     actualChangesetSourceTag = MapillaryLayer.getInstance().getChangesetSourceTag();

--- a/test/unit/org/openstreetmap/josm/plugins/mapillary/MapillarySequenceTest.java
+++ b/test/unit/org/openstreetmap/josm/plugins/mapillary/MapillarySequenceTest.java
@@ -21,11 +21,11 @@ import org.openstreetmap.josm.data.coor.LatLon;
  */
 public class MapillarySequenceTest {
 
-  private final MapillaryImage img1 = new MapillaryImage("key1", new LatLon(0.1, 0.1), 90, false);
-  private final MapillaryImage img2 = new MapillaryImage("key2", new LatLon(0.2, 0.2), 90, false);
-  private final MapillaryImage img3 = new MapillaryImage("key3", new LatLon(0.3, 0.3), 90, false);
-  private final MapillaryImage img4 = new MapillaryImage("key4", new LatLon(0.4, 0.4), 90, false);
-  private final MapillaryImage imgWithoutSeq = new MapillaryImage("key5", new LatLon(0.5, 0.5), 90, false);
+  private final MapillaryImage img1 = new MapillaryImage("key1", new LatLon(0.1, 0.1), 90, false, false);
+  private final MapillaryImage img2 = new MapillaryImage("key2", new LatLon(0.2, 0.2), 90, false, false);
+  private final MapillaryImage img3 = new MapillaryImage("key3", new LatLon(0.3, 0.3), 90, false, false);
+  private final MapillaryImage img4 = new MapillaryImage("key4", new LatLon(0.4, 0.4), 90, false, false);
+  private final MapillaryImage imgWithoutSeq = new MapillaryImage("key5", new LatLon(0.5, 0.5), 90, false, false);
   private final MapillarySequence seq = new MapillarySequence();
 
   /**

--- a/test/unit/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryPreferenceSettingTest.java
+++ b/test/unit/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryPreferenceSettingTest.java
@@ -23,6 +23,7 @@ import org.openstreetmap.josm.data.preferences.BooleanProperty;
 import org.openstreetmap.josm.data.preferences.StringProperty;
 import org.openstreetmap.josm.gui.preferences.PreferenceTabbedPane;
 import org.openstreetmap.josm.plugins.mapillary.io.download.MapillaryDownloader.DOWNLOAD_MODE;
+import org.openstreetmap.josm.plugins.mapillary.io.download.MapillaryDownloader.PRIVATE_IMAGE_DOWNLOAD_MODE;
 import org.openstreetmap.josm.plugins.mapillary.utils.TestUtil.MapillaryTestRules;
 import org.openstreetmap.josm.testutils.JOSMTestRules;
 import org.openstreetmap.josm.tools.I18n;
@@ -80,15 +81,17 @@ public class MapillaryPreferenceSettingTest {
   @Test
   public void testOk() {
     MapillaryPreferenceSetting settings = new MapillaryPreferenceSetting();
+    String arbitrary = "arbitrary";
 
     // Initialize the properties with some arbitrary value to make sure they are not unset
-    new StringProperty("mapillary.display-hour", "default").put("arbitrary");
-    new StringProperty("mapillary.format-24", "default").put("arbitrary");
-    new StringProperty("mapillary.move-to-picture", "default").put("arbitrary");
-    new StringProperty("mapillary.hover-enabled", "default").put("arbitrary");
-    new StringProperty("mapillary.dark-mode", "default").put("arbitrary");
-    new StringProperty("mapillary.download-mode", "default").put("arbitrary");
-    new StringProperty("mapillary.prefetch-image-count", "default").put("arbitrary");
+    new StringProperty("mapillary.display-hour", "default").put(arbitrary);
+    new StringProperty("mapillary.format-24", "default").put(arbitrary);
+    new StringProperty("mapillary.move-to-picture", "default").put(arbitrary);
+    new StringProperty("mapillary.hover-enabled", "default").put(arbitrary);
+    new StringProperty("mapillary.dark-mode", "default").put(arbitrary);
+    new StringProperty("mapillary.download-mode", "default").put(arbitrary);
+    new StringProperty("mapillary.prefetch-image-count", "default").put(arbitrary);
+    new StringProperty("mapillary.imageMode", "default").put(arbitrary);
 
     // Test checkboxes
     settings.ok();
@@ -124,8 +127,16 @@ public class MapillaryPreferenceSettingTest {
         new StringProperty("mapillary.download-mode", "default").get(),
         DOWNLOAD_MODE.fromLabel(
           ((JComboBox<String>) getPrivateFieldValue(settings, "downloadModeComboBox")).getSelectedItem().toString()
-        ).getPrefId()
-      );
+          ).getPrefId()
+        );
+    }
+    for (int i = 0; i < ((JComboBox<PRIVATE_IMAGE_DOWNLOAD_MODE>) getPrivateFieldValue(settings, "privateImages"))
+      .getItemCount(); i++) {
+      ((JComboBox<PRIVATE_IMAGE_DOWNLOAD_MODE>) getPrivateFieldValue(settings, "privateImages")).setSelectedIndex(i);
+      settings.ok();
+      assertEquals(
+        new StringProperty("mapillary.imageMode", "default").get(), ((PRIVATE_IMAGE_DOWNLOAD_MODE) ((JComboBox<PRIVATE_IMAGE_DOWNLOAD_MODE>) getPrivateFieldValue(settings, "privateImages")).getSelectedItem()).getPrefId()
+        );
     }
   }
 

--- a/test/unit/org/openstreetmap/josm/plugins/mapillary/history/MapillaryRecordTest.java
+++ b/test/unit/org/openstreetmap/josm/plugins/mapillary/history/MapillaryRecordTest.java
@@ -52,9 +52,9 @@ public class MapillaryRecordTest {
   @Before
   public void setUp() {
     record = new MapillaryRecord();
-    img1 = new MapillaryImage("key1__________________", new LatLon(0.1, 0.1), 0.1, false);
-    img2 = new MapillaryImage("key2__________________", new LatLon(0.2, 0.2), 0.2, false);
-    img3 = new MapillaryImage("key3__________________", new LatLon(0.3, 0.3), 0.3, false);
+    img1 = new MapillaryImage("key1__________________", new LatLon(0.1, 0.1), 0.1, false, false);
+    img2 = new MapillaryImage("key2__________________", new LatLon(0.2, 0.2), 0.2, false, false);
+    img3 = new MapillaryImage("key3__________________", new LatLon(0.3, 0.3), 0.3, false, false);
     if (MapillaryLayer.hasInstance() && MapillaryLayer.getInstance().getData().getImages().size() >= 1) {
       MapillaryLayer.getInstance().getData().getImages().clear();
     }

--- a/test/unit/org/openstreetmap/josm/plugins/mapillary/io/download/SequenceDownloadRunnableTest.java
+++ b/test/unit/org/openstreetmap/josm/plugins/mapillary/io/download/SequenceDownloadRunnableTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.openstreetmap.josm.data.Bounds;
 import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.plugins.mapillary.MapillaryLayer;
+import org.openstreetmap.josm.plugins.mapillary.oauth.MapillaryUser;
 import org.openstreetmap.josm.plugins.mapillary.utils.MapillaryProperties;
 import org.openstreetmap.josm.plugins.mapillary.utils.TestUtil;
 import org.openstreetmap.josm.plugins.mapillary.utils.TestUtil.MapillaryTestRules;
@@ -43,6 +44,7 @@ public class SequenceDownloadRunnableTest {
 
   @Before
   public void setUp() {
+    MapillaryUser.setTokenValid(false);
     MapillaryLayer.getInstance().getData().remove(MapillaryLayer.getInstance().getData().getImages());
     assertEquals(0, MapillaryLayer.getInstance().getData().getImages().size());
 

--- a/test/unit/org/openstreetmap/josm/plugins/mapillary/io/download/SequenceDownloadRunnableTest.java
+++ b/test/unit/org/openstreetmap/josm/plugins/mapillary/io/download/SequenceDownloadRunnableTest.java
@@ -24,7 +24,6 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import org.openstreetmap.josm.data.Bounds;
-import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.plugins.mapillary.MapillaryLayer;
 import org.openstreetmap.josm.plugins.mapillary.oauth.MapillaryUser;
 import org.openstreetmap.josm.plugins.mapillary.utils.MapillaryProperties;
@@ -54,7 +53,6 @@ public class SequenceDownloadRunnableTest {
 
   @After
   public void tearDown() {
-    MainApplication.getLayerManager().resetState();
     TestUtil.setAPIv3BaseUrl(oldBaseUrl);
   }
 

--- a/test/unit/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryURLTest.java
+++ b/test/unit/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryURLTest.java
@@ -27,24 +27,27 @@ public class MapillaryURLTest {
     @Test
     public void testSearchDetections() {
       final String expectedLayerParameter = "layers=trafficsigns";
-      assertUrlEquals(MapillaryURL.APIv3.searchDetections(null), "https://a.mapillary.com/v3/image_detections", CLIENT_ID_QUERY_PART, expectedLayerParameter, SORT_BY_KEY);
+      assertUrlEquals(MapillaryURL.APIv3.searchDetections(null).iterator().next(),
+          "https://a.mapillary.com/v3/image_detections", CLIENT_ID_QUERY_PART, expectedLayerParameter, SORT_BY_KEY);
     }
 
     @Test
     public void testSearchImages() {
-      assertUrlEquals(MapillaryURL.APIv3.searchImages(null), "https://a.mapillary.com/v3/images", CLIENT_ID_QUERY_PART);
+      assertUrlEquals(MapillaryURL.APIv3.searchImages(null).iterator().next(), "https://a.mapillary.com/v3/images",
+          CLIENT_ID_QUERY_PART);
     }
 
     @Test
     public void testSearchSequences() throws UnsupportedEncodingException {
       assertUrlEquals(
-        MapillaryURL.APIv3.searchSequences(new Bounds(new LatLon(1, 2), new LatLon(3, 4), true)),
+          MapillaryURL.APIv3.searchSequences(new Bounds(new LatLon(1, 2), new LatLon(3, 4), true)).iterator().next(),
         "https://a.mapillary.com/v3/sequences",
         CLIENT_ID_QUERY_PART,
         "bbox=" + URLEncoder.encode("2.0,1.0,4.0,3.0", StandardCharsets.UTF_8.name())
       );
 
-      assertUrlEquals(MapillaryURL.APIv3.searchSequences(null), "https://a.mapillary.com/v3/sequences", CLIENT_ID_QUERY_PART);
+      assertUrlEquals(MapillaryURL.APIv3.searchSequences(null).iterator().next(),
+          "https://a.mapillary.com/v3/sequences", CLIENT_ID_QUERY_PART);
     }
 
     @Test

--- a/test/unit/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryURLTest.java
+++ b/test/unit/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryURLTest.java
@@ -130,11 +130,12 @@ public class MapillaryURLTest {
 
   @Test
   public void testConnectURL() {
+    String expectedScope = "scope=user%3Aread+org%3Aread+public%3Aupload+public%3Awrite+private%3Aread";
     assertUrlEquals(
         MapillaryURL.MainWebsite.connect("http://redirect-host/ä"),
         "https://www.mapillary.com/connect",
         CLIENT_ID_QUERY_PART,
-        "scope=user%3Aread+public%3Aupload+public%3Awrite+private%3Aread",
+        expectedScope,
         "response_type=token",
         "redirect_uri=http%3A%2F%2Fredirect-host%2F%C3%A4"
     );
@@ -143,7 +144,7 @@ public class MapillaryURLTest {
         MapillaryURL.MainWebsite.connect(null),
         "https://www.mapillary.com/connect",
         CLIENT_ID_QUERY_PART,
-        "scope=user%3Aread+public%3Aupload+public%3Awrite+private%3Aread",
+        expectedScope,
         "response_type=token"
     );
 
@@ -151,7 +152,7 @@ public class MapillaryURLTest {
         MapillaryURL.MainWebsite.connect(""),
         "https://www.mapillary.com/connect",
         CLIENT_ID_QUERY_PART,
-        "scope=user%3Aread+public%3Aupload+public%3Awrite+private%3Aread",
+        expectedScope,
         "response_type=token"
     );
   }

--- a/test/unit/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryURLTest.java
+++ b/test/unit/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryURLTest.java
@@ -134,7 +134,7 @@ public class MapillaryURLTest {
         MapillaryURL.MainWebsite.connect("http://redirect-host/ä"),
         "https://www.mapillary.com/connect",
         CLIENT_ID_QUERY_PART,
-        "scope=user%3Aread+public%3Aupload+public%3Awrite",
+        "scope=user%3Aread+public%3Aupload+public%3Awrite+private%3Aread",
         "response_type=token",
         "redirect_uri=http%3A%2F%2Fredirect-host%2F%C3%A4"
     );
@@ -143,7 +143,7 @@ public class MapillaryURLTest {
         MapillaryURL.MainWebsite.connect(null),
         "https://www.mapillary.com/connect",
         CLIENT_ID_QUERY_PART,
-        "scope=user%3Aread+public%3Aupload+public%3Awrite",
+        "scope=user%3Aread+public%3Aupload+public%3Awrite+private%3Aread",
         "response_type=token"
     );
 
@@ -151,7 +151,7 @@ public class MapillaryURLTest {
         MapillaryURL.MainWebsite.connect(""),
         "https://www.mapillary.com/connect",
         CLIENT_ID_QUERY_PART,
-        "scope=user%3Aread+public%3Aupload+public%3Awrite",
+        "scope=user%3Aread+public%3Aupload+public%3Awrite+private%3Aread",
         "response_type=token"
     );
   }

--- a/test/unit/org/openstreetmap/josm/plugins/mapillary/utils/api/JsonImageDetailsDecoderTest.java
+++ b/test/unit/org/openstreetmap/josm/plugins/mapillary/utils/api/JsonImageDetailsDecoderTest.java
@@ -39,9 +39,9 @@ public class JsonImageDetailsDecoderTest {
       JsonImageDetailsDecoderTest.class.getResourceAsStream("/api/v3/responses/searchImages.json")
     ).readObject();
     MapillaryData data = new MapillaryDataMock();
-    MapillaryImage img1 = new MapillaryImage("_yA5uXuSNugmsK5VucU6Bg", new LatLon(0, 0), 0, false);
-    MapillaryImage img2 = new MapillaryImage("nmF-Wq4EvVTgAUmBicSCCg", new LatLon(0, 0), 0, false);
-    MapillaryImage img3 = new MapillaryImage("arbitrary_key", new LatLon(0, 0), 0, false);
+    MapillaryImage img1 = new MapillaryImage("_yA5uXuSNugmsK5VucU6Bg", new LatLon(0, 0), 0, false, false);
+    MapillaryImage img2 = new MapillaryImage("nmF-Wq4EvVTgAUmBicSCCg", new LatLon(0, 0), 0, false, false);
+    MapillaryImage img3 = new MapillaryImage("arbitrary_key", new LatLon(0, 0), 0, false, false);
     MapillaryAbstractImage img4 = new MapillaryImportedImage(new LatLon(0, 0), 0, null, false);
     img4.setCapturedAt(0);
     data.add(img1);

--- a/test/unit/org/openstreetmap/josm/plugins/mapillary/utils/api/JsonLocationChangesetEncoderTest.java
+++ b/test/unit/org/openstreetmap/josm/plugins/mapillary/utils/api/JsonLocationChangesetEncoderTest.java
@@ -14,7 +14,8 @@ public class JsonLocationChangesetEncoderTest {
 
   @Test
   public void testSingleImageChangeset() {
-    MapillaryImage image = new MapillaryImage("wMAqAFr3xE9072G8Al6WLQ", new LatLon(50.44612, 13.3323), 10.0, false);
+    MapillaryImage image = new MapillaryImage("wMAqAFr3xE9072G8Al6WLQ", new LatLon(50.44612, 13.3323), 10.0, false,
+        false);
     image.move(0.1111, 0.22222);
     image.turn(273.3);
     image.stopMoving();
@@ -24,7 +25,8 @@ public class JsonLocationChangesetEncoderTest {
 
   @Test
   public void testTranslationOnlyChangeset() {
-    MapillaryImage image = new MapillaryImage("translationOnlyChangesetImageKey", new LatLon(50.44612, 13.3323), 10.0, false);
+    MapillaryImage image = new MapillaryImage("translationOnlyChangesetImageKey", new LatLon(50.44612, 13.3323), 10.0,
+        false, false);
     image.move(0.1111, 0.22222);
     image.stopMoving();
 
@@ -33,7 +35,8 @@ public class JsonLocationChangesetEncoderTest {
 
   @Test
   public void testRotationOnlyChangeset() {
-    MapillaryImage image = new MapillaryImage("rotationOnlyChangesetImageKey", new LatLon(50.44612, 13.3323), 10.0, false);
+    MapillaryImage image = new MapillaryImage("rotationOnlyChangesetImageKey", new LatLon(50.44612, 13.3323), 10.0,
+        false, false);
     image.turn(-80.3);
     image.stopMoving();
 
@@ -42,14 +45,15 @@ public class JsonLocationChangesetEncoderTest {
 
   @Test
   public void testMultipleImagesChangeset() throws IllegalArgumentException {
-    MapillaryImage image1 = new MapillaryImage("wMAqAFr3xE9072G8Al6WLQ", new LatLon(50.44612, 13.3323), 10.0, false);
+    MapillaryImage image1 = new MapillaryImage("wMAqAFr3xE9072G8Al6WLQ", new LatLon(50.44612, 13.3323), 10.0, false,
+        false);
     image1.move(0.1111, 0.22222);
     image1.turn(273.3);
     image1.stopMoving();
-    MapillaryImage image2 = new MapillaryImage("7erPn382xDMtmfdh0xtvUw", new LatLon(0, 0), 0, false);
+    MapillaryImage image2 = new MapillaryImage("7erPn382xDMtmfdh0xtvUw", new LatLon(0, 0), 0, false, false);
     image2.move(13.3328, 50.44619);
     image2.stopMoving();
-    MapillaryImage image3 = new MapillaryImage("invalid image key will be ignored", new LatLon(0, 0), 0, false);
+    MapillaryImage image3 = new MapillaryImage("invalid image key will be ignored", new LatLon(0, 0), 0, false, false);
     image3.turn(13.4);
     image3.stopMoving();
 

--- a/test/unit/org/openstreetmap/josm/plugins/mapillary/utils/api/JsonSequencesDecoderTest.java
+++ b/test/unit/org/openstreetmap/josm/plugins/mapillary/utils/api/JsonSequencesDecoderTest.java
@@ -99,11 +99,11 @@ public class JsonSequencesDecoderTest {
     assertEquals(2, exampleSequence.getImages().size());
 
     assertEquals(
-      new MapillaryImage("76P0YUrlDD_lF6J7Od3yoA", new LatLon(16.43279, 7.246085), 96.71454, false),
+        new MapillaryImage("76P0YUrlDD_lF6J7Od3yoA", new LatLon(16.43279, 7.246085), 96.71454, false, false),
       exampleSequence.getImages().get(0)
     );
     assertEquals(
-      new MapillaryImage("Ap_8E0BwoAqqewhJaEbFyQ", new LatLon(16.432799, 7.246082), 96.47705000000002, false),
+        new MapillaryImage("Ap_8E0BwoAqqewhJaEbFyQ", new LatLon(16.432799, 7.246082), 96.47705000000002, false, false),
       exampleSequence.getImages().get(1)
     );
   }


### PR DESCRIPTION
This adds the ability for private repositories to be seen in JOSM.

Notes: ~~This should probably be merged after #2 (I'll rebase when #2 is merged).~~

I'd like feedback on the colour scheme I used for private pictures (I used purple to clearly distinguish them).

It looks like org:read is not currently an available scope, although the "scope" list indicates it exists (or it isn't available for API keys anyway), so I removed it here. I'll need some way to read user orgs later though.

JOSM does have a call very similar to `MapillaryUtils#browse` (`OpenBrowser#displayUrl`). I'll check and see if there are items that can be taken from the `MapillaryUtils` function and put into `OpenBrowser` (lately, at home, JOSM hasn't been able to open links, probably due to changing Linux desktop standards, and I don't know if Mapillary is affected yet). I just indicated that it was available and @Deprecated it for now.

I did fix a deadlock I encountered as I was testing the plugin (its probably a race condition) that occurred when I was debugging, and it was a fairly easy fix. (Possible JOSM bug report here: https://josm.openstreetmap.de/ticket/18656 )